### PR TITLE
Upgrade cf-cli from 7.2 to 7.3

### DIFF
--- a/ci/images/backup-and-restore-minimal/Dockerfile
+++ b/ci/images/backup-and-restore-minimal/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:bionic
 
 ENV go_version 1.17
-ENV cf_cli_version 7.2.0
+ENV cf_cli_version 7.3.0
 ENV bosh_cli_version 6.0.0
 ENV om_cli_version 0.42.0
 ENV om_cli_6_version 6.2.0


### PR DESCRIPTION
- backup-and-restore-minimal image
- the latest cf cli adds a new flag, DRATs fails against the latest
  cf-cli and this should allow the tests to run correctly

Signed-off-by: Neil Hickey <nhickey@vmware.com>