### PR TITLE
Make BBR CLI more robust to large stdout streams

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,8 @@ watch:
 	ginkgo watch -r -skipPackage integration,system,backup,s3-config-validator
 
 test-unit:
-	ginkgo -p -r -skipPackage integration,system,s3-config-validator
+	ginkgo -p -r -skipPackage integration,system,s3-config-validator,ssh
+	ginkgo -r ssh
 
 test-integration:
 	ginkgo -r -trace integration

--- a/bosh/fakes/fake_bosh_client.go
+++ b/bosh/fakes/fake_bosh_client.go
@@ -45,15 +45,16 @@ func (fake *FakeBoshClient) FindInstances(arg1 string) ([]orchestrator.Instance,
 	fake.findInstancesArgsForCall = append(fake.findInstancesArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.FindInstancesStub
+	fakeReturns := fake.findInstancesReturns
 	fake.recordInvocation("FindInstances", []interface{}{arg1})
 	fake.findInstancesMutex.Unlock()
-	if fake.FindInstancesStub != nil {
-		return fake.FindInstancesStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.findInstancesReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -108,15 +109,16 @@ func (fake *FakeBoshClient) GetManifest(arg1 string) (string, error) {
 	fake.getManifestArgsForCall = append(fake.getManifestArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.GetManifestStub
+	fakeReturns := fake.getManifestReturns
 	fake.recordInvocation("GetManifest", []interface{}{arg1})
 	fake.getManifestMutex.Unlock()
-	if fake.GetManifestStub != nil {
-		return fake.GetManifestStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getManifestReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/bosh/fakes/fake_logger.go
+++ b/bosh/fakes/fake_logger.go
@@ -47,9 +47,10 @@ func (fake *FakeLogger) Debug(arg1 string, arg2 string, arg3 ...interface{}) {
 		arg2 string
 		arg3 []interface{}
 	}{arg1, arg2, arg3})
+	stub := fake.DebugStub
 	fake.recordInvocation("Debug", []interface{}{arg1, arg2, arg3})
 	fake.debugMutex.Unlock()
-	if fake.DebugStub != nil {
+	if stub != nil {
 		fake.DebugStub(arg1, arg2, arg3...)
 	}
 }
@@ -80,9 +81,10 @@ func (fake *FakeLogger) Error(arg1 string, arg2 string, arg3 ...interface{}) {
 		arg2 string
 		arg3 []interface{}
 	}{arg1, arg2, arg3})
+	stub := fake.ErrorStub
 	fake.recordInvocation("Error", []interface{}{arg1, arg2, arg3})
 	fake.errorMutex.Unlock()
-	if fake.ErrorStub != nil {
+	if stub != nil {
 		fake.ErrorStub(arg1, arg2, arg3...)
 	}
 }
@@ -113,9 +115,10 @@ func (fake *FakeLogger) Info(arg1 string, arg2 string, arg3 ...interface{}) {
 		arg2 string
 		arg3 []interface{}
 	}{arg1, arg2, arg3})
+	stub := fake.InfoStub
 	fake.recordInvocation("Info", []interface{}{arg1, arg2, arg3})
 	fake.infoMutex.Unlock()
-	if fake.InfoStub != nil {
+	if stub != nil {
 		fake.InfoStub(arg1, arg2, arg3...)
 	}
 }
@@ -146,9 +149,10 @@ func (fake *FakeLogger) Warn(arg1 string, arg2 string, arg3 ...interface{}) {
 		arg2 string
 		arg3 []interface{}
 	}{arg1, arg2, arg3})
+	stub := fake.WarnStub
 	fake.recordInvocation("Warn", []interface{}{arg1, arg2, arg3})
 	fake.warnMutex.Unlock()
-	if fake.WarnStub != nil {
+	if stub != nil {
 		fake.WarnStub(arg1, arg2, arg3...)
 	}
 }

--- a/executor/fakes/fake_executable.go
+++ b/executor/fakes/fake_executable.go
@@ -27,15 +27,16 @@ func (fake *FakeExecutable) Execute() error {
 	ret, specificReturn := fake.executeReturnsOnCall[len(fake.executeArgsForCall)]
 	fake.executeArgsForCall = append(fake.executeArgsForCall, struct {
 	}{})
+	stub := fake.ExecuteStub
+	fakeReturns := fake.executeReturns
 	fake.recordInvocation("Execute", []interface{}{})
 	fake.executeMutex.Unlock()
-	if fake.ExecuteStub != nil {
-		return fake.ExecuteStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.executeReturns
 	return fakeReturns.result1
 }
 

--- a/executor/fakes/fake_executor.go
+++ b/executor/fakes/fake_executor.go
@@ -34,15 +34,16 @@ func (fake *FakeExecutor) Run(arg1 [][]executor.Executable) []error {
 	fake.runArgsForCall = append(fake.runArgsForCall, struct {
 		arg1 [][]executor.Executable
 	}{arg1Copy})
+	stub := fake.RunStub
+	fakeReturns := fake.runReturns
 	fake.recordInvocation("Run", []interface{}{arg1Copy})
 	fake.runMutex.Unlock()
-	if fake.RunStub != nil {
-		return fake.RunStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.runReturns
 	return fakeReturns.result1
 }
 

--- a/instance/deployed_instance_test.go
+++ b/instance/deployed_instance_test.go
@@ -312,7 +312,7 @@ var _ = Describe("DeployedInstance", func() {
 			It("uses the remote runner to create each job's backup folder and run each backup script providing the "+
 				"correct ARTIFACT_DIRECTORY and BBR_ARTIFACT_DIRECTORY", func() {
 				Expect(remoteRunner.CreateDirectoryCallCount()).To(Equal(3))
-				Expect(remoteRunner.RunScriptWithEnvCallCount()).To(Equal(3))
+				Expect(remoteRunner.RunScriptWithEnvGetStdoutCallCount()).To(Equal(3))
 				Expect([]string{
 					remoteRunner.CreateDirectoryArgsForCall(0),
 					remoteRunner.CreateDirectoryArgsForCall(1),
@@ -323,21 +323,21 @@ var _ = Describe("DeployedInstance", func() {
 					"/var/vcap/store/bbr-backup/baz",
 				))
 
-				specifiedScriptPath, specifiedEnvVars, _ := remoteRunner.RunScriptWithEnvArgsForCall(0)
+				specifiedScriptPath, specifiedEnvVars, _ := remoteRunner.RunScriptWithEnvGetStdoutArgsForCall(0)
 				Expect(specifiedScriptPath).To(Equal("/var/vcap/jobs/foo/bin/bbr/backup"))
 				Expect(specifiedEnvVars).To(Equal(map[string]string{
 					"ARTIFACT_DIRECTORY":     "/var/vcap/store/bbr-backup/foo/",
 					"BBR_ARTIFACT_DIRECTORY": "/var/vcap/store/bbr-backup/foo/",
 				}))
 
-				specifiedScriptPath, specifiedEnvVars, _ = remoteRunner.RunScriptWithEnvArgsForCall(1)
+				specifiedScriptPath, specifiedEnvVars, _ = remoteRunner.RunScriptWithEnvGetStdoutArgsForCall(1)
 				Expect(specifiedScriptPath).To(Equal("/var/vcap/jobs/bar/bin/bbr/backup"))
 				Expect(specifiedEnvVars).To(Equal(map[string]string{
 					"ARTIFACT_DIRECTORY":     "/var/vcap/store/bbr-backup/bar/",
 					"BBR_ARTIFACT_DIRECTORY": "/var/vcap/store/bbr-backup/bar/",
 				}))
 
-				specifiedScriptPath, specifiedEnvVars, _ = remoteRunner.RunScriptWithEnvArgsForCall(2)
+				specifiedScriptPath, specifiedEnvVars, _ = remoteRunner.RunScriptWithEnvGetStdoutArgsForCall(2)
 				Expect(specifiedScriptPath).To(Equal("/var/vcap/jobs/baz/bin/bbr/backup"))
 				Expect(specifiedEnvVars).To(Equal(map[string]string{
 					"ARTIFACT_DIRECTORY":     "/var/vcap/store/bbr-backup/baz/",
@@ -413,7 +413,7 @@ var _ = Describe("DeployedInstance", func() {
 				"correct BBR_ARTIFACT_DIRECTORY and ARTIFACT_DIRECTORY", func() {
 
 				Expect(remoteRunner.CreateDirectoryCallCount()).To(Equal(2))
-				Expect(remoteRunner.RunScriptWithEnvCallCount()).To(Equal(2))
+				Expect(remoteRunner.RunScriptWithEnvGetStdoutCallCount()).To(Equal(2))
 				Expect([]string{
 					remoteRunner.CreateDirectoryArgsForCall(0),
 					remoteRunner.CreateDirectoryArgsForCall(1),
@@ -421,14 +421,14 @@ var _ = Describe("DeployedInstance", func() {
 					"/var/vcap/store/bbr-backup/foo",
 					"/var/vcap/store/bbr-backup/baz-dave-backup-one-restore-all",
 				))
-				specifiedScriptPath, specifiedEnvVars, _ := remoteRunner.RunScriptWithEnvArgsForCall(0)
+				specifiedScriptPath, specifiedEnvVars, _ := remoteRunner.RunScriptWithEnvGetStdoutArgsForCall(0)
 				Expect(specifiedScriptPath).To(Equal("/var/vcap/jobs/foo/bin/bbr/backup"))
 				Expect(specifiedEnvVars).To(Equal(map[string]string{
 					"ARTIFACT_DIRECTORY":     "/var/vcap/store/bbr-backup/foo/",
 					"BBR_ARTIFACT_DIRECTORY": "/var/vcap/store/bbr-backup/foo/",
 				}))
 
-				specifiedScriptPath, specifiedEnvVars, _ = remoteRunner.RunScriptWithEnvArgsForCall(1)
+				specifiedScriptPath, specifiedEnvVars, _ = remoteRunner.RunScriptWithEnvGetStdoutArgsForCall(1)
 				Expect(specifiedScriptPath).To(Equal("/var/vcap/jobs/baz/bin/bbr/backup"))
 				Expect(specifiedEnvVars).To(Equal(map[string]string{
 					"ARTIFACT_DIRECTORY":     "/var/vcap/store/bbr-backup/baz-dave-backup-one-restore-all/",
@@ -513,7 +513,7 @@ var _ = Describe("DeployedInstance", func() {
 					),
 				})
 
-				remoteRunner.RunScriptWithEnvStub = func(cmd string, envVars map[string]string, label string) (string, error) {
+				remoteRunner.RunScriptWithEnvGetStdoutStub = func(cmd string, envVars map[string]string, label string) (string, error) {
 					if strings.Contains(cmd, "jobs/bar") {
 						return "", fmt.Errorf("no space left on device")
 					} else if strings.Contains(cmd, "jobs/baz") {
@@ -593,23 +593,23 @@ var _ = Describe("DeployedInstance", func() {
 			})
 
 			It("uses the remote runner to run each restore script providing the correct ARTIFACT_DIRECTORY", func() {
-				Expect(remoteRunner.RunScriptWithEnvCallCount()).To(Equal(3))
+				Expect(remoteRunner.RunScriptWithEnvGetStdoutCallCount()).To(Equal(3))
 
-				specifiedScriptPath, specifiedEnvVars, _ := remoteRunner.RunScriptWithEnvArgsForCall(0)
+				specifiedScriptPath, specifiedEnvVars, _ := remoteRunner.RunScriptWithEnvGetStdoutArgsForCall(0)
 				Expect(specifiedScriptPath).To(Equal("/var/vcap/jobs/foo/bin/bbr/restore"))
 				Expect(specifiedEnvVars).To(Equal(map[string]string{
 					"ARTIFACT_DIRECTORY":     "/var/vcap/store/bbr-backup/foo/",
 					"BBR_ARTIFACT_DIRECTORY": "/var/vcap/store/bbr-backup/foo/",
 				}))
 
-				specifiedScriptPath, specifiedEnvVars, _ = remoteRunner.RunScriptWithEnvArgsForCall(1)
+				specifiedScriptPath, specifiedEnvVars, _ = remoteRunner.RunScriptWithEnvGetStdoutArgsForCall(1)
 				Expect(specifiedScriptPath).To(Equal("/var/vcap/jobs/bar/bin/bbr/restore"))
 				Expect(specifiedEnvVars).To(Equal(map[string]string{
 					"ARTIFACT_DIRECTORY":     "/var/vcap/store/bbr-backup/bar/",
 					"BBR_ARTIFACT_DIRECTORY": "/var/vcap/store/bbr-backup/bar/",
 				}))
 
-				specifiedScriptPath, specifiedEnvVars, _ = remoteRunner.RunScriptWithEnvArgsForCall(2)
+				specifiedScriptPath, specifiedEnvVars, _ = remoteRunner.RunScriptWithEnvGetStdoutArgsForCall(2)
 				Expect(specifiedScriptPath).To(Equal("/var/vcap/jobs/baz/bin/bbr/restore"))
 				Expect(specifiedEnvVars).To(Equal(map[string]string{
 					"ARTIFACT_DIRECTORY":     "/var/vcap/store/bbr-backup/baz/",
@@ -695,23 +695,23 @@ var _ = Describe("DeployedInstance", func() {
 			})
 
 			It("uses the remote runner to create each job's backup folder and run each backup script providing the correct BBR_ARTIFACT_DIRECTORY and ARTIFACT_DIRECTORY", func() {
-				Expect(remoteRunner.RunScriptWithEnvCallCount()).To(Equal(3))
+				Expect(remoteRunner.RunScriptWithEnvGetStdoutCallCount()).To(Equal(3))
 
-				specifiedScriptPath, specifiedEnvVars, _ := remoteRunner.RunScriptWithEnvArgsForCall(0)
+				specifiedScriptPath, specifiedEnvVars, _ := remoteRunner.RunScriptWithEnvGetStdoutArgsForCall(0)
 				Expect(specifiedScriptPath).To(Equal("/var/vcap/jobs/foo/bin/bbr/restore"))
 				Expect(specifiedEnvVars).To(Equal(map[string]string{
 					"ARTIFACT_DIRECTORY":     "/var/vcap/store/bbr-backup/foo/",
 					"BBR_ARTIFACT_DIRECTORY": "/var/vcap/store/bbr-backup/foo/",
 				}))
 
-				specifiedScriptPath, specifiedEnvVars, _ = remoteRunner.RunScriptWithEnvArgsForCall(1)
+				specifiedScriptPath, specifiedEnvVars, _ = remoteRunner.RunScriptWithEnvGetStdoutArgsForCall(1)
 				Expect(specifiedScriptPath).To(Equal("/var/vcap/jobs/bar/bin/bbr/restore"))
 				Expect(specifiedEnvVars).To(Equal(map[string]string{
 					"ARTIFACT_DIRECTORY":     "/var/vcap/store/bbr-backup/bar/",
 					"BBR_ARTIFACT_DIRECTORY": "/var/vcap/store/bbr-backup/bar/",
 				}))
 
-				specifiedScriptPath, specifiedEnvVars, _ = remoteRunner.RunScriptWithEnvArgsForCall(2)
+				specifiedScriptPath, specifiedEnvVars, _ = remoteRunner.RunScriptWithEnvGetStdoutArgsForCall(2)
 				Expect(specifiedScriptPath).To(Equal("/var/vcap/jobs/baz/bin/bbr/restore"))
 				Expect(specifiedEnvVars).To(Equal(map[string]string{
 					"ARTIFACT_DIRECTORY":     "/var/vcap/store/bbr-backup/special-backup/",
@@ -761,7 +761,7 @@ var _ = Describe("DeployedInstance", func() {
 					),
 				})
 
-				remoteRunner.RunScriptWithEnvStub = func(cmd string, envVars map[string]string, label string) (string, error) {
+				remoteRunner.RunScriptWithEnvGetStdoutStub = func(cmd string, envVars map[string]string, label string) (string, error) {
 					if strings.Contains(cmd, "jobs/bar") {
 						return "", fmt.Errorf("no space left on device")
 					} else if strings.Contains(cmd, "jobs/baz") {

--- a/instance/deployed_instance_test.go
+++ b/instance/deployed_instance_test.go
@@ -312,7 +312,7 @@ var _ = Describe("DeployedInstance", func() {
 			It("uses the remote runner to create each job's backup folder and run each backup script providing the "+
 				"correct ARTIFACT_DIRECTORY and BBR_ARTIFACT_DIRECTORY", func() {
 				Expect(remoteRunner.CreateDirectoryCallCount()).To(Equal(3))
-				Expect(remoteRunner.RunScriptWithEnvGetStdoutCallCount()).To(Equal(3))
+				Expect(remoteRunner.RunScriptWithEnvCallCount()).To(Equal(3))
 				Expect([]string{
 					remoteRunner.CreateDirectoryArgsForCall(0),
 					remoteRunner.CreateDirectoryArgsForCall(1),
@@ -323,21 +323,21 @@ var _ = Describe("DeployedInstance", func() {
 					"/var/vcap/store/bbr-backup/baz",
 				))
 
-				specifiedScriptPath, specifiedEnvVars, _ := remoteRunner.RunScriptWithEnvGetStdoutArgsForCall(0)
+				specifiedScriptPath, specifiedEnvVars, _ := remoteRunner.RunScriptWithEnvArgsForCall(0)
 				Expect(specifiedScriptPath).To(Equal("/var/vcap/jobs/foo/bin/bbr/backup"))
 				Expect(specifiedEnvVars).To(Equal(map[string]string{
 					"ARTIFACT_DIRECTORY":     "/var/vcap/store/bbr-backup/foo/",
 					"BBR_ARTIFACT_DIRECTORY": "/var/vcap/store/bbr-backup/foo/",
 				}))
 
-				specifiedScriptPath, specifiedEnvVars, _ = remoteRunner.RunScriptWithEnvGetStdoutArgsForCall(1)
+				specifiedScriptPath, specifiedEnvVars, _ = remoteRunner.RunScriptWithEnvArgsForCall(1)
 				Expect(specifiedScriptPath).To(Equal("/var/vcap/jobs/bar/bin/bbr/backup"))
 				Expect(specifiedEnvVars).To(Equal(map[string]string{
 					"ARTIFACT_DIRECTORY":     "/var/vcap/store/bbr-backup/bar/",
 					"BBR_ARTIFACT_DIRECTORY": "/var/vcap/store/bbr-backup/bar/",
 				}))
 
-				specifiedScriptPath, specifiedEnvVars, _ = remoteRunner.RunScriptWithEnvGetStdoutArgsForCall(2)
+				specifiedScriptPath, specifiedEnvVars, _ = remoteRunner.RunScriptWithEnvArgsForCall(2)
 				Expect(specifiedScriptPath).To(Equal("/var/vcap/jobs/baz/bin/bbr/backup"))
 				Expect(specifiedEnvVars).To(Equal(map[string]string{
 					"ARTIFACT_DIRECTORY":     "/var/vcap/store/bbr-backup/baz/",
@@ -413,7 +413,7 @@ var _ = Describe("DeployedInstance", func() {
 				"correct BBR_ARTIFACT_DIRECTORY and ARTIFACT_DIRECTORY", func() {
 
 				Expect(remoteRunner.CreateDirectoryCallCount()).To(Equal(2))
-				Expect(remoteRunner.RunScriptWithEnvGetStdoutCallCount()).To(Equal(2))
+				Expect(remoteRunner.RunScriptWithEnvCallCount()).To(Equal(2))
 				Expect([]string{
 					remoteRunner.CreateDirectoryArgsForCall(0),
 					remoteRunner.CreateDirectoryArgsForCall(1),
@@ -421,14 +421,14 @@ var _ = Describe("DeployedInstance", func() {
 					"/var/vcap/store/bbr-backup/foo",
 					"/var/vcap/store/bbr-backup/baz-dave-backup-one-restore-all",
 				))
-				specifiedScriptPath, specifiedEnvVars, _ := remoteRunner.RunScriptWithEnvGetStdoutArgsForCall(0)
+				specifiedScriptPath, specifiedEnvVars, _ := remoteRunner.RunScriptWithEnvArgsForCall(0)
 				Expect(specifiedScriptPath).To(Equal("/var/vcap/jobs/foo/bin/bbr/backup"))
 				Expect(specifiedEnvVars).To(Equal(map[string]string{
 					"ARTIFACT_DIRECTORY":     "/var/vcap/store/bbr-backup/foo/",
 					"BBR_ARTIFACT_DIRECTORY": "/var/vcap/store/bbr-backup/foo/",
 				}))
 
-				specifiedScriptPath, specifiedEnvVars, _ = remoteRunner.RunScriptWithEnvGetStdoutArgsForCall(1)
+				specifiedScriptPath, specifiedEnvVars, _ = remoteRunner.RunScriptWithEnvArgsForCall(1)
 				Expect(specifiedScriptPath).To(Equal("/var/vcap/jobs/baz/bin/bbr/backup"))
 				Expect(specifiedEnvVars).To(Equal(map[string]string{
 					"ARTIFACT_DIRECTORY":     "/var/vcap/store/bbr-backup/baz-dave-backup-one-restore-all/",
@@ -513,13 +513,13 @@ var _ = Describe("DeployedInstance", func() {
 					),
 				})
 
-				remoteRunner.RunScriptWithEnvGetStdoutStub = func(cmd string, envVars map[string]string, label string) (string, error) {
+				remoteRunner.RunScriptWithEnvStub = func(cmd string, envVars map[string]string, label string) error {
 					if strings.Contains(cmd, "jobs/bar") {
-						return "", fmt.Errorf("no space left on device")
+						return fmt.Errorf("no space left on device")
 					} else if strings.Contains(cmd, "jobs/baz") {
-						return "", fmt.Errorf("huge failure")
+						return fmt.Errorf("huge failure")
 					} else {
-						return "not relevant", nil
+						return nil
 					}
 				}
 			})
@@ -593,23 +593,23 @@ var _ = Describe("DeployedInstance", func() {
 			})
 
 			It("uses the remote runner to run each restore script providing the correct ARTIFACT_DIRECTORY", func() {
-				Expect(remoteRunner.RunScriptWithEnvGetStdoutCallCount()).To(Equal(3))
+				Expect(remoteRunner.RunScriptWithEnvCallCount()).To(Equal(3))
 
-				specifiedScriptPath, specifiedEnvVars, _ := remoteRunner.RunScriptWithEnvGetStdoutArgsForCall(0)
+				specifiedScriptPath, specifiedEnvVars, _ := remoteRunner.RunScriptWithEnvArgsForCall(0)
 				Expect(specifiedScriptPath).To(Equal("/var/vcap/jobs/foo/bin/bbr/restore"))
 				Expect(specifiedEnvVars).To(Equal(map[string]string{
 					"ARTIFACT_DIRECTORY":     "/var/vcap/store/bbr-backup/foo/",
 					"BBR_ARTIFACT_DIRECTORY": "/var/vcap/store/bbr-backup/foo/",
 				}))
 
-				specifiedScriptPath, specifiedEnvVars, _ = remoteRunner.RunScriptWithEnvGetStdoutArgsForCall(1)
+				specifiedScriptPath, specifiedEnvVars, _ = remoteRunner.RunScriptWithEnvArgsForCall(1)
 				Expect(specifiedScriptPath).To(Equal("/var/vcap/jobs/bar/bin/bbr/restore"))
 				Expect(specifiedEnvVars).To(Equal(map[string]string{
 					"ARTIFACT_DIRECTORY":     "/var/vcap/store/bbr-backup/bar/",
 					"BBR_ARTIFACT_DIRECTORY": "/var/vcap/store/bbr-backup/bar/",
 				}))
 
-				specifiedScriptPath, specifiedEnvVars, _ = remoteRunner.RunScriptWithEnvGetStdoutArgsForCall(2)
+				specifiedScriptPath, specifiedEnvVars, _ = remoteRunner.RunScriptWithEnvArgsForCall(2)
 				Expect(specifiedScriptPath).To(Equal("/var/vcap/jobs/baz/bin/bbr/restore"))
 				Expect(specifiedEnvVars).To(Equal(map[string]string{
 					"ARTIFACT_DIRECTORY":     "/var/vcap/store/bbr-backup/baz/",
@@ -695,23 +695,23 @@ var _ = Describe("DeployedInstance", func() {
 			})
 
 			It("uses the remote runner to create each job's backup folder and run each backup script providing the correct BBR_ARTIFACT_DIRECTORY and ARTIFACT_DIRECTORY", func() {
-				Expect(remoteRunner.RunScriptWithEnvGetStdoutCallCount()).To(Equal(3))
+				Expect(remoteRunner.RunScriptWithEnvCallCount()).To(Equal(3))
 
-				specifiedScriptPath, specifiedEnvVars, _ := remoteRunner.RunScriptWithEnvGetStdoutArgsForCall(0)
+				specifiedScriptPath, specifiedEnvVars, _ := remoteRunner.RunScriptWithEnvArgsForCall(0)
 				Expect(specifiedScriptPath).To(Equal("/var/vcap/jobs/foo/bin/bbr/restore"))
 				Expect(specifiedEnvVars).To(Equal(map[string]string{
 					"ARTIFACT_DIRECTORY":     "/var/vcap/store/bbr-backup/foo/",
 					"BBR_ARTIFACT_DIRECTORY": "/var/vcap/store/bbr-backup/foo/",
 				}))
 
-				specifiedScriptPath, specifiedEnvVars, _ = remoteRunner.RunScriptWithEnvGetStdoutArgsForCall(1)
+				specifiedScriptPath, specifiedEnvVars, _ = remoteRunner.RunScriptWithEnvArgsForCall(1)
 				Expect(specifiedScriptPath).To(Equal("/var/vcap/jobs/bar/bin/bbr/restore"))
 				Expect(specifiedEnvVars).To(Equal(map[string]string{
 					"ARTIFACT_DIRECTORY":     "/var/vcap/store/bbr-backup/bar/",
 					"BBR_ARTIFACT_DIRECTORY": "/var/vcap/store/bbr-backup/bar/",
 				}))
 
-				specifiedScriptPath, specifiedEnvVars, _ = remoteRunner.RunScriptWithEnvGetStdoutArgsForCall(2)
+				specifiedScriptPath, specifiedEnvVars, _ = remoteRunner.RunScriptWithEnvArgsForCall(2)
 				Expect(specifiedScriptPath).To(Equal("/var/vcap/jobs/baz/bin/bbr/restore"))
 				Expect(specifiedEnvVars).To(Equal(map[string]string{
 					"ARTIFACT_DIRECTORY":     "/var/vcap/store/bbr-backup/special-backup/",
@@ -761,13 +761,13 @@ var _ = Describe("DeployedInstance", func() {
 					),
 				})
 
-				remoteRunner.RunScriptWithEnvGetStdoutStub = func(cmd string, envVars map[string]string, label string) (string, error) {
+				remoteRunner.RunScriptWithEnvStub = func(cmd string, envVars map[string]string, label string) error {
 					if strings.Contains(cmd, "jobs/bar") {
-						return "", fmt.Errorf("no space left on device")
+						return fmt.Errorf("no space left on device")
 					} else if strings.Contains(cmd, "jobs/baz") {
-						return "", fmt.Errorf("huge failure")
+						return fmt.Errorf("huge failure")
 					} else {
-						return "not relevant", nil
+						return nil
 					}
 				}
 			})

--- a/instance/fakes/fake_job_finder.go
+++ b/instance/fakes/fake_job_finder.go
@@ -37,15 +37,16 @@ func (fake *FakeJobFinder) FindJobs(arg1 instance.InstanceIdentifier, arg2 ssh.R
 		arg2 ssh.RemoteRunner
 		arg3 instance.ManifestQuerier
 	}{arg1, arg2, arg3})
+	stub := fake.FindJobsStub
+	fakeReturns := fake.findJobsReturns
 	fake.recordInvocation("FindJobs", []interface{}{arg1, arg2, arg3})
 	fake.findJobsMutex.Unlock()
-	if fake.FindJobsStub != nil {
-		return fake.FindJobsStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.findJobsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/instance/fakes/fake_logger.go
+++ b/instance/fakes/fake_logger.go
@@ -47,9 +47,10 @@ func (fake *FakeLogger) Debug(arg1 string, arg2 string, arg3 ...interface{}) {
 		arg2 string
 		arg3 []interface{}
 	}{arg1, arg2, arg3})
+	stub := fake.DebugStub
 	fake.recordInvocation("Debug", []interface{}{arg1, arg2, arg3})
 	fake.debugMutex.Unlock()
-	if fake.DebugStub != nil {
+	if stub != nil {
 		fake.DebugStub(arg1, arg2, arg3...)
 	}
 }
@@ -80,9 +81,10 @@ func (fake *FakeLogger) Error(arg1 string, arg2 string, arg3 ...interface{}) {
 		arg2 string
 		arg3 []interface{}
 	}{arg1, arg2, arg3})
+	stub := fake.ErrorStub
 	fake.recordInvocation("Error", []interface{}{arg1, arg2, arg3})
 	fake.errorMutex.Unlock()
-	if fake.ErrorStub != nil {
+	if stub != nil {
 		fake.ErrorStub(arg1, arg2, arg3...)
 	}
 }
@@ -113,9 +115,10 @@ func (fake *FakeLogger) Info(arg1 string, arg2 string, arg3 ...interface{}) {
 		arg2 string
 		arg3 []interface{}
 	}{arg1, arg2, arg3})
+	stub := fake.InfoStub
 	fake.recordInvocation("Info", []interface{}{arg1, arg2, arg3})
 	fake.infoMutex.Unlock()
-	if fake.InfoStub != nil {
+	if stub != nil {
 		fake.InfoStub(arg1, arg2, arg3...)
 	}
 }
@@ -146,9 +149,10 @@ func (fake *FakeLogger) Warn(arg1 string, arg2 string, arg3 ...interface{}) {
 		arg2 string
 		arg3 []interface{}
 	}{arg1, arg2, arg3})
+	stub := fake.WarnStub
 	fake.recordInvocation("Warn", []interface{}{arg1, arg2, arg3})
 	fake.warnMutex.Unlock()
-	if fake.WarnStub != nil {
+	if stub != nil {
 		fake.WarnStub(arg1, arg2, arg3...)
 	}
 }

--- a/instance/fakes/fake_manifest_querier.go
+++ b/instance/fakes/fake_manifest_querier.go
@@ -47,15 +47,16 @@ func (fake *FakeManifestQuerier) FindReleaseName(arg1 string, arg2 string) (stri
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.FindReleaseNameStub
+	fakeReturns := fake.findReleaseNameReturns
 	fake.recordInvocation("FindReleaseName", []interface{}{arg1, arg2})
 	fake.findReleaseNameMutex.Unlock()
-	if fake.FindReleaseNameStub != nil {
-		return fake.FindReleaseNameStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.findReleaseNameReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -111,15 +112,16 @@ func (fake *FakeManifestQuerier) IsJobBackupOneRestoreAll(arg1 string, arg2 stri
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.IsJobBackupOneRestoreAllStub
+	fakeReturns := fake.isJobBackupOneRestoreAllReturns
 	fake.recordInvocation("IsJobBackupOneRestoreAll", []interface{}{arg1, arg2})
 	fake.isJobBackupOneRestoreAllMutex.Unlock()
-	if fake.IsJobBackupOneRestoreAllStub != nil {
-		return fake.IsJobBackupOneRestoreAllStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.isJobBackupOneRestoreAllReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/instance/fakes/fake_manifest_querier_creator.go
+++ b/instance/fakes/fake_manifest_querier_creator.go
@@ -31,15 +31,17 @@ func (fake *FakeManifestQuerierCreator) Spy(arg1 string) (instance.ManifestQueri
 	fake.argsForCall = append(fake.argsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.Stub
+	returns := fake.returns
 	fake.recordInvocation("ManifestQuerierCreator", []interface{}{arg1})
 	fake.mutex.Unlock()
-	if fake.Stub != nil {
-		return fake.Stub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.returns.result1, fake.returns.result2
+	return returns.result1, returns.result2
 }
 
 func (fake *FakeManifestQuerierCreator) CallCount() int {

--- a/instance/job.go
+++ b/instance/job.go
@@ -124,7 +124,7 @@ func (j Job) Backup() error {
 		}
 
 		env := artifactDirectoryVariables(j.BackupArtifactDirectory())
-		_, err = j.remoteRunner.RunScriptWithEnvGetStdout(
+		err = j.remoteRunner.RunScriptWithEnv(
 			string(j.backupScript),
 			env,
 			fmt.Sprintf("backup %s on %s", j.name, j.instanceIdentifier),
@@ -178,7 +178,7 @@ func (j Job) PostBackupUnlock(afterSuccessfulBackup bool) error {
 		env := map[string]string{
 			"BBR_AFTER_BACKUP_SCRIPTS_SUCCESSFUL": strconv.FormatBool(afterSuccessfulBackup),
 		}
-		_, err := j.remoteRunner.RunScriptWithEnvGetStdout(
+		err := j.remoteRunner.RunScriptWithEnv(
 			string(j.postBackupScript),
 			env,
 			fmt.Sprintf("post-backup unlock %s on %s", j.name, j.instanceIdentifier),
@@ -230,7 +230,7 @@ func (j Job) Restore() error {
 		j.Logger.Info("bbr", "Restoring %s on %s...", j.name, j.instanceIdentifier)
 
 		env := artifactDirectoryVariables(j.RestoreArtifactDirectory())
-		_, err := j.remoteRunner.RunScriptWithEnvGetStdout(
+		err := j.remoteRunner.RunScriptWithEnv(
 			string(j.restoreScript), env,
 			fmt.Sprintf("restore %s on %s", j.name, j.instanceIdentifier),
 		)

--- a/instance/job.go
+++ b/instance/job.go
@@ -124,7 +124,7 @@ func (j Job) Backup() error {
 		}
 
 		env := artifactDirectoryVariables(j.BackupArtifactDirectory())
-		_, err = j.remoteRunner.RunScriptWithEnv(
+		_, err = j.remoteRunner.RunScriptWithEnvGetStdout(
 			string(j.backupScript),
 			env,
 			fmt.Sprintf("backup %s on %s", j.name, j.instanceIdentifier),
@@ -178,7 +178,7 @@ func (j Job) PostBackupUnlock(afterSuccessfulBackup bool) error {
 		env := map[string]string{
 			"BBR_AFTER_BACKUP_SCRIPTS_SUCCESSFUL": strconv.FormatBool(afterSuccessfulBackup),
 		}
-		_, err := j.remoteRunner.RunScriptWithEnv(
+		_, err := j.remoteRunner.RunScriptWithEnvGetStdout(
 			string(j.postBackupScript),
 			env,
 			fmt.Sprintf("post-backup unlock %s on %s", j.name, j.instanceIdentifier),
@@ -230,7 +230,7 @@ func (j Job) Restore() error {
 		j.Logger.Info("bbr", "Restoring %s on %s...", j.name, j.instanceIdentifier)
 
 		env := artifactDirectoryVariables(j.RestoreArtifactDirectory())
-		_, err := j.remoteRunner.RunScriptWithEnv(
+		_, err := j.remoteRunner.RunScriptWithEnvGetStdout(
 			string(j.restoreScript), env,
 			fmt.Sprintf("restore %s on %s", j.name, j.instanceIdentifier),
 		)

--- a/instance/job_finder.go
+++ b/instance/job_finder.go
@@ -101,7 +101,7 @@ func (j *JobFinderFromScripts) findBBRScripts(instanceIdentifierForLogging Insta
 }
 
 func (j *JobFinderFromScripts) findMetadata(instanceIdentifier InstanceIdentifier, script Script, remoteRunner ssh.RemoteRunner) (*Metadata, error) {
-	metadataContent, err := remoteRunner.RunScriptWithEnv(
+	metadataContent, err := remoteRunner.RunScriptWithEnvGetStdout(
 		string(script),
 		map[string]string{"BBR_VERSION": j.bbrVersion},
 		fmt.Sprintf("find metadata for %s on %s", script.JobName(), instanceIdentifier),

--- a/instance/job_finder_test.go
+++ b/instance/job_finder_test.go
@@ -252,7 +252,7 @@ var _ = Describe("JobFinderFromScripts", func() {
 			Context("when metadata is valid", func() {
 				BeforeEach(func() {
 					remoteRunner.FindFilesReturns([]string{"/var/vcap/jobs/consul_agent/bin/bbr/metadata"}, nil)
-					remoteRunner.RunScriptWithEnvReturns(`---
+					remoteRunner.RunScriptWithEnvGetStdoutReturns(`---
 backup_name: consul_backup
 restore_name: consul_backup
 backup_should_be_locked_before:
@@ -262,7 +262,7 @@ backup_should_be_locked_before:
 
 				It("attaches the metadata to the corresponding jobs", func() {
 					By("executing the metadata scripts passing the correct arguments", func() {
-						cmd, env, _ := remoteRunner.RunScriptWithEnvArgsForCall(0)
+						cmd, env, _ := remoteRunner.RunScriptWithEnvGetStdoutArgsForCall(0)
 						Expect(cmd).To(Equal("/var/vcap/jobs/consul_agent/bin/bbr/metadata"))
 						Expect(env).To(Equal(map[string]string{"BBR_VERSION": bbrVersion}))
 					})
@@ -300,7 +300,7 @@ backup_should_be_locked_before:
 
 					It("attaches the metadata to the corresponding jobs", func() {
 						By("executing the metadata scripts passing the correct arguments", func() {
-							cmd, env, _ := remoteRunner.RunScriptWithEnvArgsForCall(0)
+							cmd, env, _ := remoteRunner.RunScriptWithEnvGetStdoutArgsForCall(0)
 							Expect(cmd).To(Equal("/var/vcap/jobs/consul_agent/bin/bbr/metadata"))
 							Expect(env).To(Equal(map[string]string{"BBR_VERSION": bbrVersion}))
 						})
@@ -355,7 +355,7 @@ backup_should_be_locked_before:
 			Context("when executing a metadata script fails", func() {
 				BeforeEach(func() {
 					remoteRunner.FindFilesReturns([]string{"/var/vcap/jobs/consul_agent/bin/bbr/metadata"}, nil)
-					remoteRunner.RunScriptWithEnvReturns("", fmt.Errorf("blah blah blah foo"))
+					remoteRunner.RunScriptWithEnvGetStdoutReturns("", fmt.Errorf("blah blah blah foo"))
 				})
 
 				It("printing the location of the error, and the original error message", func() {
@@ -370,7 +370,7 @@ backup_should_be_locked_before:
 			Context("when a metadata script returns invalid metadata YAML", func() {
 				BeforeEach(func() {
 					remoteRunner.FindFilesReturns([]string{"/var/vcap/jobs/consul_agent/bin/bbr/metadata"}, nil)
-					remoteRunner.RunScriptWithEnvReturns(`this metadata is missing all the keys`, nil)
+					remoteRunner.RunScriptWithEnvGetStdoutReturns(`this metadata is missing all the keys`, nil)
 				})
 
 				It("prints the location of the error", func() {
@@ -383,14 +383,14 @@ backup_should_be_locked_before:
 			Context("when the bbr job is disabled", func() {
 				BeforeEach(func() {
 					remoteRunner.FindFilesReturns([]string{"/var/vcap/jobs/consul_agent/bin/bbr/metadata"}, nil)
-					remoteRunner.RunScriptWithEnvReturns(`---
+					remoteRunner.RunScriptWithEnvGetStdoutReturns(`---
 skip_bbr_scripts: true
 `, nil)
 				})
 
 				It("ignores the job", func() {
 					By("executing the metadata scripts passing the correct arguments", func() {
-						cmd, env, _ := remoteRunner.RunScriptWithEnvArgsForCall(0)
+						cmd, env, _ := remoteRunner.RunScriptWithEnvGetStdoutArgsForCall(0)
 						Expect(cmd).To(Equal("/var/vcap/jobs/consul_agent/bin/bbr/metadata"))
 						Expect(env).To(Equal(map[string]string{"BBR_VERSION": bbrVersion}))
 					})

--- a/instance/job_test.go
+++ b/instance/job_test.go
@@ -369,10 +369,10 @@ var _ = Describe("Job", func() {
 
 			It("uses the remote runnerto run the script", func() {
 				Expect(remoteRunner.CreateDirectoryCallCount()).To(Equal(1))
-				Expect(remoteRunner.RunScriptWithEnvCallCount()).To(Equal(1))
+				Expect(remoteRunner.RunScriptWithEnvGetStdoutCallCount()).To(Equal(1))
 
 				Expect(remoteRunner.CreateDirectoryArgsForCall(0)).To(Equal("/var/vcap/store/bbr-backup/jobname"))
-				specifiedScriptPath, specifiedEnvVars, _ := remoteRunner.RunScriptWithEnvArgsForCall(0)
+				specifiedScriptPath, specifiedEnvVars, _ := remoteRunner.RunScriptWithEnvGetStdoutArgsForCall(0)
 				Expect(specifiedScriptPath).To(Equal("/var/vcap/jobs/jobname/bin/bbr/backup"))
 				Expect(specifiedEnvVars).To(SatisfyAll(
 					HaveLen(2),
@@ -383,7 +383,7 @@ var _ = Describe("Job", func() {
 
 			Context("backup script runs successfully", func() {
 				BeforeEach(func() {
-					remoteRunner.RunScriptWithEnvReturns("stdout", nil)
+					remoteRunner.RunScriptWithEnvGetStdoutReturns("stdout", nil)
 				})
 
 				It("succeeds", func() {
@@ -393,7 +393,7 @@ var _ = Describe("Job", func() {
 
 			Context("backup script fails", func() {
 				BeforeEach(func() {
-					remoteRunner.RunScriptWithEnvReturns("", fmt.Errorf("some weird error"))
+					remoteRunner.RunScriptWithEnvGetStdoutReturns("", fmt.Errorf("some weird error"))
 				})
 
 				It("fails", func() {
@@ -430,9 +430,9 @@ var _ = Describe("Job", func() {
 			})
 
 			It("uses the remote runner to run the script", func() {
-				Expect(remoteRunner.RunScriptWithEnvCallCount()).To(Equal(1))
+				Expect(remoteRunner.RunScriptWithEnvGetStdoutCallCount()).To(Equal(1))
 
-				specifiedScriptPath, specifiedEnvVars, _ := remoteRunner.RunScriptWithEnvArgsForCall(0)
+				specifiedScriptPath, specifiedEnvVars, _ := remoteRunner.RunScriptWithEnvGetStdoutArgsForCall(0)
 				Expect(specifiedScriptPath).To(Equal("/var/vcap/jobs/jobname/bin/bbr/restore"))
 				Expect(specifiedEnvVars).To(SatisfyAll(
 					HaveLen(2),
@@ -443,7 +443,7 @@ var _ = Describe("Job", func() {
 
 			Context("restore script runs successfully", func() {
 				BeforeEach(func() {
-					remoteRunner.RunScriptWithEnvReturns("", nil)
+					remoteRunner.RunScriptWithEnvGetStdoutReturns("", nil)
 				})
 
 				It("succeeds", func() {
@@ -453,7 +453,7 @@ var _ = Describe("Job", func() {
 
 			Context("restore script fails", func() {
 				BeforeEach(func() {
-					remoteRunner.RunScriptWithEnvReturns("", fmt.Errorf("it went wrong"))
+					remoteRunner.RunScriptWithEnvGetStdoutReturns("", fmt.Errorf("it went wrong"))
 				})
 
 				It("fails", func() {
@@ -572,15 +572,15 @@ var _ = Describe("Job", func() {
 				})
 
 				It("uses remote runner to run the script", func() {
-					Expect(remoteRunner.RunScriptWithEnvCallCount()).To(Equal(1))
-					cmd, envVars, _ := remoteRunner.RunScriptWithEnvArgsForCall(0)
+					Expect(remoteRunner.RunScriptWithEnvGetStdoutCallCount()).To(Equal(1))
+					cmd, envVars, _ := remoteRunner.RunScriptWithEnvGetStdoutArgsForCall(0)
 					Expect(cmd).To(Equal("/var/vcap/jobs/jobname/bin/bbr/post-backup-unlock"))
 					Expect(envVars).To(HaveKeyWithValue("BBR_AFTER_BACKUP_SCRIPTS_SUCCESSFUL", "true"))
 				})
 
 				Context("post-backup-unlock script runs successfully", func() {
 					BeforeEach(func() {
-						remoteRunner.RunScriptWithEnvReturns("stdout", nil)
+						remoteRunner.RunScriptWithEnvGetStdoutReturns("stdout", nil)
 					})
 
 					It("succeeds", func() {
@@ -598,8 +598,8 @@ var _ = Describe("Job", func() {
 				})
 
 				It("uses remote runner to run the script", func() {
-					Expect(remoteRunner.RunScriptWithEnvCallCount()).To(Equal(1))
-					cmd, envVars, _ := remoteRunner.RunScriptWithEnvArgsForCall(0)
+					Expect(remoteRunner.RunScriptWithEnvGetStdoutCallCount()).To(Equal(1))
+					cmd, envVars, _ := remoteRunner.RunScriptWithEnvGetStdoutArgsForCall(0)
 					Expect(cmd).To(Equal("/var/vcap/jobs/jobname/bin/bbr/post-backup-unlock"))
 					Expect(envVars).To(HaveKeyWithValue("BBR_AFTER_BACKUP_SCRIPTS_SUCCESSFUL", "false"))
 				})
@@ -608,7 +608,7 @@ var _ = Describe("Job", func() {
 
 			Context("post-backup-unlock script fails", func() {
 				BeforeEach(func() {
-					remoteRunner.RunScriptWithEnvReturns("", fmt.Errorf("it failed"))
+					remoteRunner.RunScriptWithEnvGetStdoutReturns("", fmt.Errorf("it failed"))
 				})
 
 				It("fails", func() {

--- a/instance/job_test.go
+++ b/instance/job_test.go
@@ -369,10 +369,10 @@ var _ = Describe("Job", func() {
 
 			It("uses the remote runnerto run the script", func() {
 				Expect(remoteRunner.CreateDirectoryCallCount()).To(Equal(1))
-				Expect(remoteRunner.RunScriptWithEnvGetStdoutCallCount()).To(Equal(1))
+				Expect(remoteRunner.RunScriptWithEnvCallCount()).To(Equal(1))
 
 				Expect(remoteRunner.CreateDirectoryArgsForCall(0)).To(Equal("/var/vcap/store/bbr-backup/jobname"))
-				specifiedScriptPath, specifiedEnvVars, _ := remoteRunner.RunScriptWithEnvGetStdoutArgsForCall(0)
+				specifiedScriptPath, specifiedEnvVars, _ := remoteRunner.RunScriptWithEnvArgsForCall(0)
 				Expect(specifiedScriptPath).To(Equal("/var/vcap/jobs/jobname/bin/bbr/backup"))
 				Expect(specifiedEnvVars).To(SatisfyAll(
 					HaveLen(2),
@@ -383,7 +383,7 @@ var _ = Describe("Job", func() {
 
 			Context("backup script runs successfully", func() {
 				BeforeEach(func() {
-					remoteRunner.RunScriptWithEnvGetStdoutReturns("stdout", nil)
+					remoteRunner.RunScriptWithEnvReturns(nil)
 				})
 
 				It("succeeds", func() {
@@ -393,7 +393,7 @@ var _ = Describe("Job", func() {
 
 			Context("backup script fails", func() {
 				BeforeEach(func() {
-					remoteRunner.RunScriptWithEnvGetStdoutReturns("", fmt.Errorf("some weird error"))
+					remoteRunner.RunScriptWithEnvReturns(fmt.Errorf("some weird error"))
 				})
 
 				It("fails", func() {
@@ -430,9 +430,9 @@ var _ = Describe("Job", func() {
 			})
 
 			It("uses the remote runner to run the script", func() {
-				Expect(remoteRunner.RunScriptWithEnvGetStdoutCallCount()).To(Equal(1))
+				Expect(remoteRunner.RunScriptWithEnvCallCount()).To(Equal(1))
 
-				specifiedScriptPath, specifiedEnvVars, _ := remoteRunner.RunScriptWithEnvGetStdoutArgsForCall(0)
+				specifiedScriptPath, specifiedEnvVars, _ := remoteRunner.RunScriptWithEnvArgsForCall(0)
 				Expect(specifiedScriptPath).To(Equal("/var/vcap/jobs/jobname/bin/bbr/restore"))
 				Expect(specifiedEnvVars).To(SatisfyAll(
 					HaveLen(2),
@@ -443,7 +443,7 @@ var _ = Describe("Job", func() {
 
 			Context("restore script runs successfully", func() {
 				BeforeEach(func() {
-					remoteRunner.RunScriptWithEnvGetStdoutReturns("", nil)
+					remoteRunner.RunScriptWithEnvReturns(nil)
 				})
 
 				It("succeeds", func() {
@@ -453,7 +453,7 @@ var _ = Describe("Job", func() {
 
 			Context("restore script fails", func() {
 				BeforeEach(func() {
-					remoteRunner.RunScriptWithEnvGetStdoutReturns("", fmt.Errorf("it went wrong"))
+					remoteRunner.RunScriptWithEnvReturns(fmt.Errorf("it went wrong"))
 				})
 
 				It("fails", func() {
@@ -572,15 +572,15 @@ var _ = Describe("Job", func() {
 				})
 
 				It("uses remote runner to run the script", func() {
-					Expect(remoteRunner.RunScriptWithEnvGetStdoutCallCount()).To(Equal(1))
-					cmd, envVars, _ := remoteRunner.RunScriptWithEnvGetStdoutArgsForCall(0)
+					Expect(remoteRunner.RunScriptWithEnvCallCount()).To(Equal(1))
+					cmd, envVars, _ := remoteRunner.RunScriptWithEnvArgsForCall(0)
 					Expect(cmd).To(Equal("/var/vcap/jobs/jobname/bin/bbr/post-backup-unlock"))
 					Expect(envVars).To(HaveKeyWithValue("BBR_AFTER_BACKUP_SCRIPTS_SUCCESSFUL", "true"))
 				})
 
 				Context("post-backup-unlock script runs successfully", func() {
 					BeforeEach(func() {
-						remoteRunner.RunScriptWithEnvGetStdoutReturns("stdout", nil)
+						remoteRunner.RunScriptWithEnvReturns(nil)
 					})
 
 					It("succeeds", func() {
@@ -598,8 +598,8 @@ var _ = Describe("Job", func() {
 				})
 
 				It("uses remote runner to run the script", func() {
-					Expect(remoteRunner.RunScriptWithEnvGetStdoutCallCount()).To(Equal(1))
-					cmd, envVars, _ := remoteRunner.RunScriptWithEnvGetStdoutArgsForCall(0)
+					Expect(remoteRunner.RunScriptWithEnvCallCount()).To(Equal(1))
+					cmd, envVars, _ := remoteRunner.RunScriptWithEnvArgsForCall(0)
 					Expect(cmd).To(Equal("/var/vcap/jobs/jobname/bin/bbr/post-backup-unlock"))
 					Expect(envVars).To(HaveKeyWithValue("BBR_AFTER_BACKUP_SCRIPTS_SUCCESSFUL", "false"))
 				})
@@ -608,7 +608,7 @@ var _ = Describe("Job", func() {
 
 			Context("post-backup-unlock script fails", func() {
 				BeforeEach(func() {
-					remoteRunner.RunScriptWithEnvGetStdoutReturns("", fmt.Errorf("it failed"))
+					remoteRunner.RunScriptWithEnvReturns(fmt.Errorf("it failed"))
 				})
 
 				It("fails", func() {

--- a/integration/director/backup_test.go
+++ b/integration/director/backup_test.go
@@ -416,7 +416,9 @@ backup_should_be_locked_before:
 			})
 
 			By("printing an error", func() {
-				Expect(session.Err).To(gbytes.Say("no such host"))
+				Expect(session.Err).To(SatisfyAny(
+					gbytes.Say("no such host"),
+					gbytes.Say("No address associated with hostname")))
 			})
 
 			By("not printing a recommendation to run bbr backup-cleanup", func() {

--- a/integration/director/pre_backup_check_test.go
+++ b/integration/director/pre_backup_check_test.go
@@ -161,7 +161,9 @@ restore_should_be_locked_before:
 		})
 
 		It("prints an error", func() {
-			Expect(session.Err).To(gbytes.Say("no such host"))
+			Expect(session.Err).To(SatisfyAny(
+				gbytes.Say("no such host"),
+				gbytes.Say("No address associated with hostname")))
 			Expect(string(session.Err.Contents())).NotTo(ContainSubstring("main.go"))
 		})
 

--- a/orchestrator/fakes/fake_artifact_copier.go
+++ b/orchestrator/fakes/fake_artifact_copier.go
@@ -43,15 +43,16 @@ func (fake *FakeArtifactCopier) DownloadBackupFromDeployment(arg1 orchestrator.B
 		arg1 orchestrator.Backup
 		arg2 orchestrator.Deployment
 	}{arg1, arg2})
+	stub := fake.DownloadBackupFromDeploymentStub
+	fakeReturns := fake.downloadBackupFromDeploymentReturns
 	fake.recordInvocation("DownloadBackupFromDeployment", []interface{}{arg1, arg2})
 	fake.downloadBackupFromDeploymentMutex.Unlock()
-	if fake.DownloadBackupFromDeploymentStub != nil {
-		return fake.DownloadBackupFromDeploymentStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.downloadBackupFromDeploymentReturns
 	return fakeReturns.result1
 }
 
@@ -104,15 +105,16 @@ func (fake *FakeArtifactCopier) UploadBackupToDeployment(arg1 orchestrator.Backu
 		arg1 orchestrator.Backup
 		arg2 orchestrator.Deployment
 	}{arg1, arg2})
+	stub := fake.UploadBackupToDeploymentStub
+	fakeReturns := fake.uploadBackupToDeploymentReturns
 	fake.recordInvocation("UploadBackupToDeployment", []interface{}{arg1, arg2})
 	fake.uploadBackupToDeploymentMutex.Unlock()
-	if fake.UploadBackupToDeploymentStub != nil {
-		return fake.UploadBackupToDeploymentStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.uploadBackupToDeploymentReturns
 	return fakeReturns.result1
 }
 

--- a/orchestrator/fakes/fake_backup.go
+++ b/orchestrator/fakes/fake_backup.go
@@ -170,15 +170,16 @@ func (fake *FakeBackup) AddChecksum(arg1 orchestrator.ArtifactIdentifier, arg2 o
 		arg1 orchestrator.ArtifactIdentifier
 		arg2 orchestrator.BackupChecksum
 	}{arg1, arg2})
+	stub := fake.AddChecksumStub
+	fakeReturns := fake.addChecksumReturns
 	fake.recordInvocation("AddChecksum", []interface{}{arg1, arg2})
 	fake.addChecksumMutex.Unlock()
-	if fake.AddChecksumStub != nil {
-		return fake.AddChecksumStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.addChecksumReturns
 	return fakeReturns.result1
 }
 
@@ -230,15 +231,16 @@ func (fake *FakeBackup) AddFinishTime(arg1 time.Time) error {
 	fake.addFinishTimeArgsForCall = append(fake.addFinishTimeArgsForCall, struct {
 		arg1 time.Time
 	}{arg1})
+	stub := fake.AddFinishTimeStub
+	fakeReturns := fake.addFinishTimeReturns
 	fake.recordInvocation("AddFinishTime", []interface{}{arg1})
 	fake.addFinishTimeMutex.Unlock()
-	if fake.AddFinishTimeStub != nil {
-		return fake.AddFinishTimeStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.addFinishTimeReturns
 	return fakeReturns.result1
 }
 
@@ -290,15 +292,16 @@ func (fake *FakeBackup) CalculateChecksum(arg1 orchestrator.ArtifactIdentifier) 
 	fake.calculateChecksumArgsForCall = append(fake.calculateChecksumArgsForCall, struct {
 		arg1 orchestrator.ArtifactIdentifier
 	}{arg1})
+	stub := fake.CalculateChecksumStub
+	fakeReturns := fake.calculateChecksumReturns
 	fake.recordInvocation("CalculateChecksum", []interface{}{arg1})
 	fake.calculateChecksumMutex.Unlock()
-	if fake.CalculateChecksumStub != nil {
-		return fake.CalculateChecksumStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.calculateChecksumReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -353,15 +356,16 @@ func (fake *FakeBackup) CreateArtifact(arg1 orchestrator.ArtifactIdentifier) (io
 	fake.createArtifactArgsForCall = append(fake.createArtifactArgsForCall, struct {
 		arg1 orchestrator.ArtifactIdentifier
 	}{arg1})
+	stub := fake.CreateArtifactStub
+	fakeReturns := fake.createArtifactReturns
 	fake.recordInvocation("CreateArtifact", []interface{}{arg1})
 	fake.createArtifactMutex.Unlock()
-	if fake.CreateArtifactStub != nil {
-		return fake.CreateArtifactStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.createArtifactReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -416,15 +420,16 @@ func (fake *FakeBackup) CreateMetadataFileWithStartTime(arg1 time.Time) error {
 	fake.createMetadataFileWithStartTimeArgsForCall = append(fake.createMetadataFileWithStartTimeArgsForCall, struct {
 		arg1 time.Time
 	}{arg1})
+	stub := fake.CreateMetadataFileWithStartTimeStub
+	fakeReturns := fake.createMetadataFileWithStartTimeReturns
 	fake.recordInvocation("CreateMetadataFileWithStartTime", []interface{}{arg1})
 	fake.createMetadataFileWithStartTimeMutex.Unlock()
-	if fake.CreateMetadataFileWithStartTimeStub != nil {
-		return fake.CreateMetadataFileWithStartTimeStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.createMetadataFileWithStartTimeReturns
 	return fakeReturns.result1
 }
 
@@ -482,15 +487,16 @@ func (fake *FakeBackup) DeploymentMatches(arg1 string, arg2 []orchestrator.Insta
 		arg1 string
 		arg2 []orchestrator.Instance
 	}{arg1, arg2Copy})
+	stub := fake.DeploymentMatchesStub
+	fakeReturns := fake.deploymentMatchesReturns
 	fake.recordInvocation("DeploymentMatches", []interface{}{arg1, arg2Copy})
 	fake.deploymentMatchesMutex.Unlock()
-	if fake.DeploymentMatchesStub != nil {
-		return fake.DeploymentMatchesStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.deploymentMatchesReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -545,15 +551,16 @@ func (fake *FakeBackup) FetchChecksum(arg1 orchestrator.ArtifactIdentifier) (orc
 	fake.fetchChecksumArgsForCall = append(fake.fetchChecksumArgsForCall, struct {
 		arg1 orchestrator.ArtifactIdentifier
 	}{arg1})
+	stub := fake.FetchChecksumStub
+	fakeReturns := fake.fetchChecksumReturns
 	fake.recordInvocation("FetchChecksum", []interface{}{arg1})
 	fake.fetchChecksumMutex.Unlock()
-	if fake.FetchChecksumStub != nil {
-		return fake.FetchChecksumStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.fetchChecksumReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -608,15 +615,16 @@ func (fake *FakeBackup) GetArtifactByteSize(arg1 orchestrator.ArtifactIdentifier
 	fake.getArtifactByteSizeArgsForCall = append(fake.getArtifactByteSizeArgsForCall, struct {
 		arg1 orchestrator.ArtifactIdentifier
 	}{arg1})
+	stub := fake.GetArtifactByteSizeStub
+	fakeReturns := fake.getArtifactByteSizeReturns
 	fake.recordInvocation("GetArtifactByteSize", []interface{}{arg1})
 	fake.getArtifactByteSizeMutex.Unlock()
-	if fake.GetArtifactByteSizeStub != nil {
-		return fake.GetArtifactByteSizeStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getArtifactByteSizeReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -671,15 +679,16 @@ func (fake *FakeBackup) GetArtifactSize(arg1 orchestrator.ArtifactIdentifier) (s
 	fake.getArtifactSizeArgsForCall = append(fake.getArtifactSizeArgsForCall, struct {
 		arg1 orchestrator.ArtifactIdentifier
 	}{arg1})
+	stub := fake.GetArtifactSizeStub
+	fakeReturns := fake.getArtifactSizeReturns
 	fake.recordInvocation("GetArtifactSize", []interface{}{arg1})
 	fake.getArtifactSizeMutex.Unlock()
-	if fake.GetArtifactSizeStub != nil {
-		return fake.GetArtifactSizeStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getArtifactSizeReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -734,15 +743,16 @@ func (fake *FakeBackup) ReadArtifact(arg1 orchestrator.ArtifactIdentifier) (io.R
 	fake.readArtifactArgsForCall = append(fake.readArtifactArgsForCall, struct {
 		arg1 orchestrator.ArtifactIdentifier
 	}{arg1})
+	stub := fake.ReadArtifactStub
+	fakeReturns := fake.readArtifactReturns
 	fake.recordInvocation("ReadArtifact", []interface{}{arg1})
 	fake.readArtifactMutex.Unlock()
-	if fake.ReadArtifactStub != nil {
-		return fake.ReadArtifactStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.readArtifactReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -797,15 +807,16 @@ func (fake *FakeBackup) SaveManifest(arg1 string) error {
 	fake.saveManifestArgsForCall = append(fake.saveManifestArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.SaveManifestStub
+	fakeReturns := fake.saveManifestReturns
 	fake.recordInvocation("SaveManifest", []interface{}{arg1})
 	fake.saveManifestMutex.Unlock()
-	if fake.SaveManifestStub != nil {
-		return fake.SaveManifestStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.saveManifestReturns
 	return fakeReturns.result1
 }
 
@@ -856,15 +867,16 @@ func (fake *FakeBackup) Valid() (bool, error) {
 	ret, specificReturn := fake.validReturnsOnCall[len(fake.validArgsForCall)]
 	fake.validArgsForCall = append(fake.validArgsForCall, struct {
 	}{})
+	stub := fake.ValidStub
+	fakeReturns := fake.validReturns
 	fake.recordInvocation("Valid", []interface{}{})
 	fake.validMutex.Unlock()
-	if fake.ValidStub != nil {
-		return fake.ValidStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.validReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/orchestrator/fakes/fake_backup_artifact.go
+++ b/orchestrator/fakes/fake_backup_artifact.go
@@ -136,15 +136,16 @@ func (fake *FakeBackupArtifact) Checksum() (orchestrator.BackupChecksum, error) 
 	ret, specificReturn := fake.checksumReturnsOnCall[len(fake.checksumArgsForCall)]
 	fake.checksumArgsForCall = append(fake.checksumArgsForCall, struct {
 	}{})
+	stub := fake.ChecksumStub
+	fakeReturns := fake.checksumReturns
 	fake.recordInvocation("Checksum", []interface{}{})
 	fake.checksumMutex.Unlock()
-	if fake.ChecksumStub != nil {
-		return fake.ChecksumStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.checksumReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -191,15 +192,16 @@ func (fake *FakeBackupArtifact) Delete() error {
 	ret, specificReturn := fake.deleteReturnsOnCall[len(fake.deleteArgsForCall)]
 	fake.deleteArgsForCall = append(fake.deleteArgsForCall, struct {
 	}{})
+	stub := fake.DeleteStub
+	fakeReturns := fake.deleteReturns
 	fake.recordInvocation("Delete", []interface{}{})
 	fake.deleteMutex.Unlock()
-	if fake.DeleteStub != nil {
-		return fake.DeleteStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.deleteReturns
 	return fakeReturns.result1
 }
 
@@ -243,15 +245,16 @@ func (fake *FakeBackupArtifact) HasCustomName() bool {
 	ret, specificReturn := fake.hasCustomNameReturnsOnCall[len(fake.hasCustomNameArgsForCall)]
 	fake.hasCustomNameArgsForCall = append(fake.hasCustomNameArgsForCall, struct {
 	}{})
+	stub := fake.HasCustomNameStub
+	fakeReturns := fake.hasCustomNameReturns
 	fake.recordInvocation("HasCustomName", []interface{}{})
 	fake.hasCustomNameMutex.Unlock()
-	if fake.HasCustomNameStub != nil {
-		return fake.HasCustomNameStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.hasCustomNameReturns
 	return fakeReturns.result1
 }
 
@@ -295,15 +298,16 @@ func (fake *FakeBackupArtifact) InstanceID() string {
 	ret, specificReturn := fake.instanceIDReturnsOnCall[len(fake.instanceIDArgsForCall)]
 	fake.instanceIDArgsForCall = append(fake.instanceIDArgsForCall, struct {
 	}{})
+	stub := fake.InstanceIDStub
+	fakeReturns := fake.instanceIDReturns
 	fake.recordInvocation("InstanceID", []interface{}{})
 	fake.instanceIDMutex.Unlock()
-	if fake.InstanceIDStub != nil {
-		return fake.InstanceIDStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.instanceIDReturns
 	return fakeReturns.result1
 }
 
@@ -347,15 +351,16 @@ func (fake *FakeBackupArtifact) InstanceIndex() string {
 	ret, specificReturn := fake.instanceIndexReturnsOnCall[len(fake.instanceIndexArgsForCall)]
 	fake.instanceIndexArgsForCall = append(fake.instanceIndexArgsForCall, struct {
 	}{})
+	stub := fake.InstanceIndexStub
+	fakeReturns := fake.instanceIndexReturns
 	fake.recordInvocation("InstanceIndex", []interface{}{})
 	fake.instanceIndexMutex.Unlock()
-	if fake.InstanceIndexStub != nil {
-		return fake.InstanceIndexStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.instanceIndexReturns
 	return fakeReturns.result1
 }
 
@@ -399,15 +404,16 @@ func (fake *FakeBackupArtifact) InstanceName() string {
 	ret, specificReturn := fake.instanceNameReturnsOnCall[len(fake.instanceNameArgsForCall)]
 	fake.instanceNameArgsForCall = append(fake.instanceNameArgsForCall, struct {
 	}{})
+	stub := fake.InstanceNameStub
+	fakeReturns := fake.instanceNameReturns
 	fake.recordInvocation("InstanceName", []interface{}{})
 	fake.instanceNameMutex.Unlock()
-	if fake.InstanceNameStub != nil {
-		return fake.InstanceNameStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.instanceNameReturns
 	return fakeReturns.result1
 }
 
@@ -451,15 +457,16 @@ func (fake *FakeBackupArtifact) Name() string {
 	ret, specificReturn := fake.nameReturnsOnCall[len(fake.nameArgsForCall)]
 	fake.nameArgsForCall = append(fake.nameArgsForCall, struct {
 	}{})
+	stub := fake.NameStub
+	fakeReturns := fake.nameReturns
 	fake.recordInvocation("Name", []interface{}{})
 	fake.nameMutex.Unlock()
-	if fake.NameStub != nil {
-		return fake.NameStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.nameReturns
 	return fakeReturns.result1
 }
 
@@ -503,15 +510,16 @@ func (fake *FakeBackupArtifact) Size() (string, error) {
 	ret, specificReturn := fake.sizeReturnsOnCall[len(fake.sizeArgsForCall)]
 	fake.sizeArgsForCall = append(fake.sizeArgsForCall, struct {
 	}{})
+	stub := fake.SizeStub
+	fakeReturns := fake.sizeReturns
 	fake.recordInvocation("Size", []interface{}{})
 	fake.sizeMutex.Unlock()
-	if fake.SizeStub != nil {
-		return fake.SizeStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.sizeReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -558,15 +566,16 @@ func (fake *FakeBackupArtifact) SizeInBytes() (int, error) {
 	ret, specificReturn := fake.sizeInBytesReturnsOnCall[len(fake.sizeInBytesArgsForCall)]
 	fake.sizeInBytesArgsForCall = append(fake.sizeInBytesArgsForCall, struct {
 	}{})
+	stub := fake.SizeInBytesStub
+	fakeReturns := fake.sizeInBytesReturns
 	fake.recordInvocation("SizeInBytes", []interface{}{})
 	fake.sizeInBytesMutex.Unlock()
-	if fake.SizeInBytesStub != nil {
-		return fake.SizeInBytesStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.sizeInBytesReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -614,15 +623,16 @@ func (fake *FakeBackupArtifact) StreamFromRemote(arg1 io.Writer) error {
 	fake.streamFromRemoteArgsForCall = append(fake.streamFromRemoteArgsForCall, struct {
 		arg1 io.Writer
 	}{arg1})
+	stub := fake.StreamFromRemoteStub
+	fakeReturns := fake.streamFromRemoteReturns
 	fake.recordInvocation("StreamFromRemote", []interface{}{arg1})
 	fake.streamFromRemoteMutex.Unlock()
-	if fake.StreamFromRemoteStub != nil {
-		return fake.StreamFromRemoteStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.streamFromRemoteReturns
 	return fakeReturns.result1
 }
 
@@ -674,15 +684,16 @@ func (fake *FakeBackupArtifact) StreamToRemote(arg1 io.Reader) error {
 	fake.streamToRemoteArgsForCall = append(fake.streamToRemoteArgsForCall, struct {
 		arg1 io.Reader
 	}{arg1})
+	stub := fake.StreamToRemoteStub
+	fakeReturns := fake.streamToRemoteReturns
 	fake.recordInvocation("StreamToRemote", []interface{}{arg1})
 	fake.streamToRemoteMutex.Unlock()
-	if fake.StreamToRemoteStub != nil {
-		return fake.StreamToRemoteStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.streamToRemoteReturns
 	return fakeReturns.result1
 }
 

--- a/orchestrator/fakes/fake_backup_manager.go
+++ b/orchestrator/fakes/fake_backup_manager.go
@@ -49,15 +49,16 @@ func (fake *FakeBackupManager) Create(arg1 string, arg2 string, arg3 orchestrato
 		arg2 string
 		arg3 orchestrator.Logger
 	}{arg1, arg2, arg3})
+	stub := fake.CreateStub
+	fakeReturns := fake.createReturns
 	fake.recordInvocation("Create", []interface{}{arg1, arg2, arg3})
 	fake.createMutex.Unlock()
-	if fake.CreateStub != nil {
-		return fake.CreateStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.createReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -113,15 +114,16 @@ func (fake *FakeBackupManager) Open(arg1 string, arg2 orchestrator.Logger) (orch
 		arg1 string
 		arg2 orchestrator.Logger
 	}{arg1, arg2})
+	stub := fake.OpenStub
+	fakeReturns := fake.openReturns
 	fake.recordInvocation("Open", []interface{}{arg1, arg2})
 	fake.openMutex.Unlock()
-	if fake.OpenStub != nil {
-		return fake.OpenStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.openReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/orchestrator/fakes/fake_deployment.go
+++ b/orchestrator/fakes/fake_deployment.go
@@ -180,15 +180,16 @@ func (fake *FakeDeployment) Backup(arg1 executor.Executor) error {
 	fake.backupArgsForCall = append(fake.backupArgsForCall, struct {
 		arg1 executor.Executor
 	}{arg1})
+	stub := fake.BackupStub
+	fakeReturns := fake.backupReturns
 	fake.recordInvocation("Backup", []interface{}{arg1})
 	fake.backupMutex.Unlock()
-	if fake.BackupStub != nil {
-		return fake.BackupStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.backupReturns
 	return fakeReturns.result1
 }
 
@@ -239,15 +240,16 @@ func (fake *FakeDeployment) BackupableInstances() []orchestrator.Instance {
 	ret, specificReturn := fake.backupableInstancesReturnsOnCall[len(fake.backupableInstancesArgsForCall)]
 	fake.backupableInstancesArgsForCall = append(fake.backupableInstancesArgsForCall, struct {
 	}{})
+	stub := fake.BackupableInstancesStub
+	fakeReturns := fake.backupableInstancesReturns
 	fake.recordInvocation("BackupableInstances", []interface{}{})
 	fake.backupableInstancesMutex.Unlock()
-	if fake.BackupableInstancesStub != nil {
-		return fake.BackupableInstancesStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.backupableInstancesReturns
 	return fakeReturns.result1
 }
 
@@ -291,15 +293,16 @@ func (fake *FakeDeployment) CheckArtifactDir() error {
 	ret, specificReturn := fake.checkArtifactDirReturnsOnCall[len(fake.checkArtifactDirArgsForCall)]
 	fake.checkArtifactDirArgsForCall = append(fake.checkArtifactDirArgsForCall, struct {
 	}{})
+	stub := fake.CheckArtifactDirStub
+	fakeReturns := fake.checkArtifactDirReturns
 	fake.recordInvocation("CheckArtifactDir", []interface{}{})
 	fake.checkArtifactDirMutex.Unlock()
-	if fake.CheckArtifactDirStub != nil {
-		return fake.CheckArtifactDirStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.checkArtifactDirReturns
 	return fakeReturns.result1
 }
 
@@ -343,15 +346,16 @@ func (fake *FakeDeployment) Cleanup() error {
 	ret, specificReturn := fake.cleanupReturnsOnCall[len(fake.cleanupArgsForCall)]
 	fake.cleanupArgsForCall = append(fake.cleanupArgsForCall, struct {
 	}{})
+	stub := fake.CleanupStub
+	fakeReturns := fake.cleanupReturns
 	fake.recordInvocation("Cleanup", []interface{}{})
 	fake.cleanupMutex.Unlock()
-	if fake.CleanupStub != nil {
-		return fake.CleanupStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.cleanupReturns
 	return fakeReturns.result1
 }
 
@@ -395,15 +399,16 @@ func (fake *FakeDeployment) CleanupPrevious() error {
 	ret, specificReturn := fake.cleanupPreviousReturnsOnCall[len(fake.cleanupPreviousArgsForCall)]
 	fake.cleanupPreviousArgsForCall = append(fake.cleanupPreviousArgsForCall, struct {
 	}{})
+	stub := fake.CleanupPreviousStub
+	fakeReturns := fake.cleanupPreviousReturns
 	fake.recordInvocation("CleanupPrevious", []interface{}{})
 	fake.cleanupPreviousMutex.Unlock()
-	if fake.CleanupPreviousStub != nil {
-		return fake.CleanupPreviousStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.cleanupPreviousReturns
 	return fakeReturns.result1
 }
 
@@ -447,15 +452,16 @@ func (fake *FakeDeployment) Instances() []orchestrator.Instance {
 	ret, specificReturn := fake.instancesReturnsOnCall[len(fake.instancesArgsForCall)]
 	fake.instancesArgsForCall = append(fake.instancesArgsForCall, struct {
 	}{})
+	stub := fake.InstancesStub
+	fakeReturns := fake.instancesReturns
 	fake.recordInvocation("Instances", []interface{}{})
 	fake.instancesMutex.Unlock()
-	if fake.InstancesStub != nil {
-		return fake.InstancesStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.instancesReturns
 	return fakeReturns.result1
 }
 
@@ -499,15 +505,16 @@ func (fake *FakeDeployment) IsBackupable() bool {
 	ret, specificReturn := fake.isBackupableReturnsOnCall[len(fake.isBackupableArgsForCall)]
 	fake.isBackupableArgsForCall = append(fake.isBackupableArgsForCall, struct {
 	}{})
+	stub := fake.IsBackupableStub
+	fakeReturns := fake.isBackupableReturns
 	fake.recordInvocation("IsBackupable", []interface{}{})
 	fake.isBackupableMutex.Unlock()
-	if fake.IsBackupableStub != nil {
-		return fake.IsBackupableStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.isBackupableReturns
 	return fakeReturns.result1
 }
 
@@ -551,15 +558,16 @@ func (fake *FakeDeployment) IsRestorable() bool {
 	ret, specificReturn := fake.isRestorableReturnsOnCall[len(fake.isRestorableArgsForCall)]
 	fake.isRestorableArgsForCall = append(fake.isRestorableArgsForCall, struct {
 	}{})
+	stub := fake.IsRestorableStub
+	fakeReturns := fake.isRestorableReturns
 	fake.recordInvocation("IsRestorable", []interface{}{})
 	fake.isRestorableMutex.Unlock()
-	if fake.IsRestorableStub != nil {
-		return fake.IsRestorableStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.isRestorableReturns
 	return fakeReturns.result1
 }
 
@@ -606,15 +614,16 @@ func (fake *FakeDeployment) PostBackupUnlock(arg1 bool, arg2 orchestrator.LockOr
 		arg2 orchestrator.LockOrderer
 		arg3 executor.Executor
 	}{arg1, arg2, arg3})
+	stub := fake.PostBackupUnlockStub
+	fakeReturns := fake.postBackupUnlockReturns
 	fake.recordInvocation("PostBackupUnlock", []interface{}{arg1, arg2, arg3})
 	fake.postBackupUnlockMutex.Unlock()
-	if fake.PostBackupUnlockStub != nil {
-		return fake.PostBackupUnlockStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.postBackupUnlockReturns
 	return fakeReturns.result1
 }
 
@@ -667,15 +676,16 @@ func (fake *FakeDeployment) PostRestoreUnlock(arg1 orchestrator.LockOrderer, arg
 		arg1 orchestrator.LockOrderer
 		arg2 executor.Executor
 	}{arg1, arg2})
+	stub := fake.PostRestoreUnlockStub
+	fakeReturns := fake.postRestoreUnlockReturns
 	fake.recordInvocation("PostRestoreUnlock", []interface{}{arg1, arg2})
 	fake.postRestoreUnlockMutex.Unlock()
-	if fake.PostRestoreUnlockStub != nil {
-		return fake.PostRestoreUnlockStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.postRestoreUnlockReturns
 	return fakeReturns.result1
 }
 
@@ -728,15 +738,16 @@ func (fake *FakeDeployment) PreBackupLock(arg1 orchestrator.LockOrderer, arg2 ex
 		arg1 orchestrator.LockOrderer
 		arg2 executor.Executor
 	}{arg1, arg2})
+	stub := fake.PreBackupLockStub
+	fakeReturns := fake.preBackupLockReturns
 	fake.recordInvocation("PreBackupLock", []interface{}{arg1, arg2})
 	fake.preBackupLockMutex.Unlock()
-	if fake.PreBackupLockStub != nil {
-		return fake.PreBackupLockStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.preBackupLockReturns
 	return fakeReturns.result1
 }
 
@@ -789,15 +800,16 @@ func (fake *FakeDeployment) PreRestoreLock(arg1 orchestrator.LockOrderer, arg2 e
 		arg1 orchestrator.LockOrderer
 		arg2 executor.Executor
 	}{arg1, arg2})
+	stub := fake.PreRestoreLockStub
+	fakeReturns := fake.preRestoreLockReturns
 	fake.recordInvocation("PreRestoreLock", []interface{}{arg1, arg2})
 	fake.preRestoreLockMutex.Unlock()
-	if fake.PreRestoreLockStub != nil {
-		return fake.PreRestoreLockStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.preRestoreLockReturns
 	return fakeReturns.result1
 }
 
@@ -848,15 +860,16 @@ func (fake *FakeDeployment) RestorableInstances() []orchestrator.Instance {
 	ret, specificReturn := fake.restorableInstancesReturnsOnCall[len(fake.restorableInstancesArgsForCall)]
 	fake.restorableInstancesArgsForCall = append(fake.restorableInstancesArgsForCall, struct {
 	}{})
+	stub := fake.RestorableInstancesStub
+	fakeReturns := fake.restorableInstancesReturns
 	fake.recordInvocation("RestorableInstances", []interface{}{})
 	fake.restorableInstancesMutex.Unlock()
-	if fake.RestorableInstancesStub != nil {
-		return fake.RestorableInstancesStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.restorableInstancesReturns
 	return fakeReturns.result1
 }
 
@@ -900,15 +913,16 @@ func (fake *FakeDeployment) Restore() error {
 	ret, specificReturn := fake.restoreReturnsOnCall[len(fake.restoreArgsForCall)]
 	fake.restoreArgsForCall = append(fake.restoreArgsForCall, struct {
 	}{})
+	stub := fake.RestoreStub
+	fakeReturns := fake.restoreReturns
 	fake.recordInvocation("Restore", []interface{}{})
 	fake.restoreMutex.Unlock()
-	if fake.RestoreStub != nil {
-		return fake.RestoreStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.restoreReturns
 	return fakeReturns.result1
 }
 
@@ -953,15 +967,16 @@ func (fake *FakeDeployment) ValidateLockingDependencies(arg1 orchestrator.LockOr
 	fake.validateLockingDependenciesArgsForCall = append(fake.validateLockingDependenciesArgsForCall, struct {
 		arg1 orchestrator.LockOrderer
 	}{arg1})
+	stub := fake.ValidateLockingDependenciesStub
+	fakeReturns := fake.validateLockingDependenciesReturns
 	fake.recordInvocation("ValidateLockingDependencies", []interface{}{arg1})
 	fake.validateLockingDependenciesMutex.Unlock()
-	if fake.ValidateLockingDependenciesStub != nil {
-		return fake.ValidateLockingDependenciesStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.validateLockingDependenciesReturns
 	return fakeReturns.result1
 }
 

--- a/orchestrator/fakes/fake_deployment_manager.go
+++ b/orchestrator/fakes/fake_deployment_manager.go
@@ -43,15 +43,16 @@ func (fake *FakeDeploymentManager) Find(arg1 string) (orchestrator.Deployment, e
 	fake.findArgsForCall = append(fake.findArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.FindStub
+	fakeReturns := fake.findReturns
 	fake.recordInvocation("Find", []interface{}{arg1})
 	fake.findMutex.Unlock()
-	if fake.FindStub != nil {
-		return fake.FindStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.findReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -107,15 +108,16 @@ func (fake *FakeDeploymentManager) SaveManifest(arg1 string, arg2 orchestrator.B
 		arg1 string
 		arg2 orchestrator.Backup
 	}{arg1, arg2})
+	stub := fake.SaveManifestStub
+	fakeReturns := fake.saveManifestReturns
 	fake.recordInvocation("SaveManifest", []interface{}{arg1, arg2})
 	fake.saveManifestMutex.Unlock()
-	if fake.SaveManifestStub != nil {
-		return fake.SaveManifestStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.saveManifestReturns
 	return fakeReturns.result1
 }
 

--- a/orchestrator/fakes/fake_instance.go
+++ b/orchestrator/fakes/fake_instance.go
@@ -173,15 +173,16 @@ func (fake *FakeInstance) ArtifactDirCreated() bool {
 	ret, specificReturn := fake.artifactDirCreatedReturnsOnCall[len(fake.artifactDirCreatedArgsForCall)]
 	fake.artifactDirCreatedArgsForCall = append(fake.artifactDirCreatedArgsForCall, struct {
 	}{})
+	stub := fake.ArtifactDirCreatedStub
+	fakeReturns := fake.artifactDirCreatedReturns
 	fake.recordInvocation("ArtifactDirCreated", []interface{}{})
 	fake.artifactDirCreatedMutex.Unlock()
-	if fake.ArtifactDirCreatedStub != nil {
-		return fake.ArtifactDirCreatedStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.artifactDirCreatedReturns
 	return fakeReturns.result1
 }
 
@@ -225,15 +226,16 @@ func (fake *FakeInstance) ArtifactDirExists() (bool, error) {
 	ret, specificReturn := fake.artifactDirExistsReturnsOnCall[len(fake.artifactDirExistsArgsForCall)]
 	fake.artifactDirExistsArgsForCall = append(fake.artifactDirExistsArgsForCall, struct {
 	}{})
+	stub := fake.ArtifactDirExistsStub
+	fakeReturns := fake.artifactDirExistsReturns
 	fake.recordInvocation("ArtifactDirExists", []interface{}{})
 	fake.artifactDirExistsMutex.Unlock()
-	if fake.ArtifactDirExistsStub != nil {
-		return fake.ArtifactDirExistsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.artifactDirExistsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -280,15 +282,16 @@ func (fake *FakeInstance) ArtifactsToBackup() []orchestrator.BackupArtifact {
 	ret, specificReturn := fake.artifactsToBackupReturnsOnCall[len(fake.artifactsToBackupArgsForCall)]
 	fake.artifactsToBackupArgsForCall = append(fake.artifactsToBackupArgsForCall, struct {
 	}{})
+	stub := fake.ArtifactsToBackupStub
+	fakeReturns := fake.artifactsToBackupReturns
 	fake.recordInvocation("ArtifactsToBackup", []interface{}{})
 	fake.artifactsToBackupMutex.Unlock()
-	if fake.ArtifactsToBackupStub != nil {
-		return fake.ArtifactsToBackupStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.artifactsToBackupReturns
 	return fakeReturns.result1
 }
 
@@ -332,15 +335,16 @@ func (fake *FakeInstance) ArtifactsToRestore() []orchestrator.BackupArtifact {
 	ret, specificReturn := fake.artifactsToRestoreReturnsOnCall[len(fake.artifactsToRestoreArgsForCall)]
 	fake.artifactsToRestoreArgsForCall = append(fake.artifactsToRestoreArgsForCall, struct {
 	}{})
+	stub := fake.ArtifactsToRestoreStub
+	fakeReturns := fake.artifactsToRestoreReturns
 	fake.recordInvocation("ArtifactsToRestore", []interface{}{})
 	fake.artifactsToRestoreMutex.Unlock()
-	if fake.ArtifactsToRestoreStub != nil {
-		return fake.ArtifactsToRestoreStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.artifactsToRestoreReturns
 	return fakeReturns.result1
 }
 
@@ -384,15 +388,16 @@ func (fake *FakeInstance) Backup() error {
 	ret, specificReturn := fake.backupReturnsOnCall[len(fake.backupArgsForCall)]
 	fake.backupArgsForCall = append(fake.backupArgsForCall, struct {
 	}{})
+	stub := fake.BackupStub
+	fakeReturns := fake.backupReturns
 	fake.recordInvocation("Backup", []interface{}{})
 	fake.backupMutex.Unlock()
-	if fake.BackupStub != nil {
-		return fake.BackupStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.backupReturns
 	return fakeReturns.result1
 }
 
@@ -436,15 +441,16 @@ func (fake *FakeInstance) Cleanup() error {
 	ret, specificReturn := fake.cleanupReturnsOnCall[len(fake.cleanupArgsForCall)]
 	fake.cleanupArgsForCall = append(fake.cleanupArgsForCall, struct {
 	}{})
+	stub := fake.CleanupStub
+	fakeReturns := fake.cleanupReturns
 	fake.recordInvocation("Cleanup", []interface{}{})
 	fake.cleanupMutex.Unlock()
-	if fake.CleanupStub != nil {
-		return fake.CleanupStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.cleanupReturns
 	return fakeReturns.result1
 }
 
@@ -488,15 +494,16 @@ func (fake *FakeInstance) CleanupPrevious() error {
 	ret, specificReturn := fake.cleanupPreviousReturnsOnCall[len(fake.cleanupPreviousArgsForCall)]
 	fake.cleanupPreviousArgsForCall = append(fake.cleanupPreviousArgsForCall, struct {
 	}{})
+	stub := fake.CleanupPreviousStub
+	fakeReturns := fake.cleanupPreviousReturns
 	fake.recordInvocation("CleanupPrevious", []interface{}{})
 	fake.cleanupPreviousMutex.Unlock()
-	if fake.CleanupPreviousStub != nil {
-		return fake.CleanupPreviousStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.cleanupPreviousReturns
 	return fakeReturns.result1
 }
 
@@ -540,15 +547,16 @@ func (fake *FakeInstance) HasMetadataRestoreNames() bool {
 	ret, specificReturn := fake.hasMetadataRestoreNamesReturnsOnCall[len(fake.hasMetadataRestoreNamesArgsForCall)]
 	fake.hasMetadataRestoreNamesArgsForCall = append(fake.hasMetadataRestoreNamesArgsForCall, struct {
 	}{})
+	stub := fake.HasMetadataRestoreNamesStub
+	fakeReturns := fake.hasMetadataRestoreNamesReturns
 	fake.recordInvocation("HasMetadataRestoreNames", []interface{}{})
 	fake.hasMetadataRestoreNamesMutex.Unlock()
-	if fake.HasMetadataRestoreNamesStub != nil {
-		return fake.HasMetadataRestoreNamesStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.hasMetadataRestoreNamesReturns
 	return fakeReturns.result1
 }
 
@@ -592,15 +600,16 @@ func (fake *FakeInstance) ID() string {
 	ret, specificReturn := fake.iDReturnsOnCall[len(fake.iDArgsForCall)]
 	fake.iDArgsForCall = append(fake.iDArgsForCall, struct {
 	}{})
+	stub := fake.IDStub
+	fakeReturns := fake.iDReturns
 	fake.recordInvocation("ID", []interface{}{})
 	fake.iDMutex.Unlock()
-	if fake.IDStub != nil {
-		return fake.IDStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.iDReturns
 	return fakeReturns.result1
 }
 
@@ -644,15 +653,16 @@ func (fake *FakeInstance) Index() string {
 	ret, specificReturn := fake.indexReturnsOnCall[len(fake.indexArgsForCall)]
 	fake.indexArgsForCall = append(fake.indexArgsForCall, struct {
 	}{})
+	stub := fake.IndexStub
+	fakeReturns := fake.indexReturns
 	fake.recordInvocation("Index", []interface{}{})
 	fake.indexMutex.Unlock()
-	if fake.IndexStub != nil {
-		return fake.IndexStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.indexReturns
 	return fakeReturns.result1
 }
 
@@ -696,15 +706,16 @@ func (fake *FakeInstance) IsBackupable() bool {
 	ret, specificReturn := fake.isBackupableReturnsOnCall[len(fake.isBackupableArgsForCall)]
 	fake.isBackupableArgsForCall = append(fake.isBackupableArgsForCall, struct {
 	}{})
+	stub := fake.IsBackupableStub
+	fakeReturns := fake.isBackupableReturns
 	fake.recordInvocation("IsBackupable", []interface{}{})
 	fake.isBackupableMutex.Unlock()
-	if fake.IsBackupableStub != nil {
-		return fake.IsBackupableStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.isBackupableReturns
 	return fakeReturns.result1
 }
 
@@ -748,15 +759,16 @@ func (fake *FakeInstance) IsRestorable() bool {
 	ret, specificReturn := fake.isRestorableReturnsOnCall[len(fake.isRestorableArgsForCall)]
 	fake.isRestorableArgsForCall = append(fake.isRestorableArgsForCall, struct {
 	}{})
+	stub := fake.IsRestorableStub
+	fakeReturns := fake.isRestorableReturns
 	fake.recordInvocation("IsRestorable", []interface{}{})
 	fake.isRestorableMutex.Unlock()
-	if fake.IsRestorableStub != nil {
-		return fake.IsRestorableStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.isRestorableReturns
 	return fakeReturns.result1
 }
 
@@ -800,15 +812,16 @@ func (fake *FakeInstance) Jobs() []orchestrator.Job {
 	ret, specificReturn := fake.jobsReturnsOnCall[len(fake.jobsArgsForCall)]
 	fake.jobsArgsForCall = append(fake.jobsArgsForCall, struct {
 	}{})
+	stub := fake.JobsStub
+	fakeReturns := fake.jobsReturns
 	fake.recordInvocation("Jobs", []interface{}{})
 	fake.jobsMutex.Unlock()
-	if fake.JobsStub != nil {
-		return fake.JobsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.jobsReturns
 	return fakeReturns.result1
 }
 
@@ -851,9 +864,10 @@ func (fake *FakeInstance) MarkArtifactDirCreated() {
 	fake.markArtifactDirCreatedMutex.Lock()
 	fake.markArtifactDirCreatedArgsForCall = append(fake.markArtifactDirCreatedArgsForCall, struct {
 	}{})
+	stub := fake.MarkArtifactDirCreatedStub
 	fake.recordInvocation("MarkArtifactDirCreated", []interface{}{})
 	fake.markArtifactDirCreatedMutex.Unlock()
-	if fake.MarkArtifactDirCreatedStub != nil {
+	if stub != nil {
 		fake.MarkArtifactDirCreatedStub()
 	}
 }
@@ -875,15 +889,16 @@ func (fake *FakeInstance) Name() string {
 	ret, specificReturn := fake.nameReturnsOnCall[len(fake.nameArgsForCall)]
 	fake.nameArgsForCall = append(fake.nameArgsForCall, struct {
 	}{})
+	stub := fake.NameStub
+	fakeReturns := fake.nameReturns
 	fake.recordInvocation("Name", []interface{}{})
 	fake.nameMutex.Unlock()
-	if fake.NameStub != nil {
-		return fake.NameStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.nameReturns
 	return fakeReturns.result1
 }
 
@@ -927,15 +942,16 @@ func (fake *FakeInstance) Restore() error {
 	ret, specificReturn := fake.restoreReturnsOnCall[len(fake.restoreArgsForCall)]
 	fake.restoreArgsForCall = append(fake.restoreArgsForCall, struct {
 	}{})
+	stub := fake.RestoreStub
+	fakeReturns := fake.restoreReturns
 	fake.recordInvocation("Restore", []interface{}{})
 	fake.restoreMutex.Unlock()
-	if fake.RestoreStub != nil {
-		return fake.RestoreStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.restoreReturns
 	return fakeReturns.result1
 }
 

--- a/orchestrator/fakes/fake_job.go
+++ b/orchestrator/fakes/fake_job.go
@@ -218,15 +218,16 @@ func (fake *FakeJob) Backup() error {
 	ret, specificReturn := fake.backupReturnsOnCall[len(fake.backupArgsForCall)]
 	fake.backupArgsForCall = append(fake.backupArgsForCall, struct {
 	}{})
+	stub := fake.BackupStub
+	fakeReturns := fake.backupReturns
 	fake.recordInvocation("Backup", []interface{}{})
 	fake.backupMutex.Unlock()
-	if fake.BackupStub != nil {
-		return fake.BackupStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.backupReturns
 	return fakeReturns.result1
 }
 
@@ -270,15 +271,16 @@ func (fake *FakeJob) BackupArtifactDirectory() string {
 	ret, specificReturn := fake.backupArtifactDirectoryReturnsOnCall[len(fake.backupArtifactDirectoryArgsForCall)]
 	fake.backupArtifactDirectoryArgsForCall = append(fake.backupArtifactDirectoryArgsForCall, struct {
 	}{})
+	stub := fake.BackupArtifactDirectoryStub
+	fakeReturns := fake.backupArtifactDirectoryReturns
 	fake.recordInvocation("BackupArtifactDirectory", []interface{}{})
 	fake.backupArtifactDirectoryMutex.Unlock()
-	if fake.BackupArtifactDirectoryStub != nil {
-		return fake.BackupArtifactDirectoryStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.backupArtifactDirectoryReturns
 	return fakeReturns.result1
 }
 
@@ -322,15 +324,16 @@ func (fake *FakeJob) BackupArtifactName() string {
 	ret, specificReturn := fake.backupArtifactNameReturnsOnCall[len(fake.backupArtifactNameArgsForCall)]
 	fake.backupArtifactNameArgsForCall = append(fake.backupArtifactNameArgsForCall, struct {
 	}{})
+	stub := fake.BackupArtifactNameStub
+	fakeReturns := fake.backupArtifactNameReturns
 	fake.recordInvocation("BackupArtifactName", []interface{}{})
 	fake.backupArtifactNameMutex.Unlock()
-	if fake.BackupArtifactNameStub != nil {
-		return fake.BackupArtifactNameStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.backupArtifactNameReturns
 	return fakeReturns.result1
 }
 
@@ -374,15 +377,16 @@ func (fake *FakeJob) BackupShouldBeLockedBefore() []orchestrator.JobSpecifier {
 	ret, specificReturn := fake.backupShouldBeLockedBeforeReturnsOnCall[len(fake.backupShouldBeLockedBeforeArgsForCall)]
 	fake.backupShouldBeLockedBeforeArgsForCall = append(fake.backupShouldBeLockedBeforeArgsForCall, struct {
 	}{})
+	stub := fake.BackupShouldBeLockedBeforeStub
+	fakeReturns := fake.backupShouldBeLockedBeforeReturns
 	fake.recordInvocation("BackupShouldBeLockedBefore", []interface{}{})
 	fake.backupShouldBeLockedBeforeMutex.Unlock()
-	if fake.BackupShouldBeLockedBeforeStub != nil {
-		return fake.BackupShouldBeLockedBeforeStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.backupShouldBeLockedBeforeReturns
 	return fakeReturns.result1
 }
 
@@ -426,15 +430,16 @@ func (fake *FakeJob) HasBackup() bool {
 	ret, specificReturn := fake.hasBackupReturnsOnCall[len(fake.hasBackupArgsForCall)]
 	fake.hasBackupArgsForCall = append(fake.hasBackupArgsForCall, struct {
 	}{})
+	stub := fake.HasBackupStub
+	fakeReturns := fake.hasBackupReturns
 	fake.recordInvocation("HasBackup", []interface{}{})
 	fake.hasBackupMutex.Unlock()
-	if fake.HasBackupStub != nil {
-		return fake.HasBackupStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.hasBackupReturns
 	return fakeReturns.result1
 }
 
@@ -478,15 +483,16 @@ func (fake *FakeJob) HasMetadataRestoreName() bool {
 	ret, specificReturn := fake.hasMetadataRestoreNameReturnsOnCall[len(fake.hasMetadataRestoreNameArgsForCall)]
 	fake.hasMetadataRestoreNameArgsForCall = append(fake.hasMetadataRestoreNameArgsForCall, struct {
 	}{})
+	stub := fake.HasMetadataRestoreNameStub
+	fakeReturns := fake.hasMetadataRestoreNameReturns
 	fake.recordInvocation("HasMetadataRestoreName", []interface{}{})
 	fake.hasMetadataRestoreNameMutex.Unlock()
-	if fake.HasMetadataRestoreNameStub != nil {
-		return fake.HasMetadataRestoreNameStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.hasMetadataRestoreNameReturns
 	return fakeReturns.result1
 }
 
@@ -530,15 +536,16 @@ func (fake *FakeJob) HasNamedBackupArtifact() bool {
 	ret, specificReturn := fake.hasNamedBackupArtifactReturnsOnCall[len(fake.hasNamedBackupArtifactArgsForCall)]
 	fake.hasNamedBackupArtifactArgsForCall = append(fake.hasNamedBackupArtifactArgsForCall, struct {
 	}{})
+	stub := fake.HasNamedBackupArtifactStub
+	fakeReturns := fake.hasNamedBackupArtifactReturns
 	fake.recordInvocation("HasNamedBackupArtifact", []interface{}{})
 	fake.hasNamedBackupArtifactMutex.Unlock()
-	if fake.HasNamedBackupArtifactStub != nil {
-		return fake.HasNamedBackupArtifactStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.hasNamedBackupArtifactReturns
 	return fakeReturns.result1
 }
 
@@ -582,15 +589,16 @@ func (fake *FakeJob) HasNamedRestoreArtifact() bool {
 	ret, specificReturn := fake.hasNamedRestoreArtifactReturnsOnCall[len(fake.hasNamedRestoreArtifactArgsForCall)]
 	fake.hasNamedRestoreArtifactArgsForCall = append(fake.hasNamedRestoreArtifactArgsForCall, struct {
 	}{})
+	stub := fake.HasNamedRestoreArtifactStub
+	fakeReturns := fake.hasNamedRestoreArtifactReturns
 	fake.recordInvocation("HasNamedRestoreArtifact", []interface{}{})
 	fake.hasNamedRestoreArtifactMutex.Unlock()
-	if fake.HasNamedRestoreArtifactStub != nil {
-		return fake.HasNamedRestoreArtifactStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.hasNamedRestoreArtifactReturns
 	return fakeReturns.result1
 }
 
@@ -634,15 +642,16 @@ func (fake *FakeJob) HasRestore() bool {
 	ret, specificReturn := fake.hasRestoreReturnsOnCall[len(fake.hasRestoreArgsForCall)]
 	fake.hasRestoreArgsForCall = append(fake.hasRestoreArgsForCall, struct {
 	}{})
+	stub := fake.HasRestoreStub
+	fakeReturns := fake.hasRestoreReturns
 	fake.recordInvocation("HasRestore", []interface{}{})
 	fake.hasRestoreMutex.Unlock()
-	if fake.HasRestoreStub != nil {
-		return fake.HasRestoreStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.hasRestoreReturns
 	return fakeReturns.result1
 }
 
@@ -686,15 +695,16 @@ func (fake *FakeJob) InstanceIdentifier() string {
 	ret, specificReturn := fake.instanceIdentifierReturnsOnCall[len(fake.instanceIdentifierArgsForCall)]
 	fake.instanceIdentifierArgsForCall = append(fake.instanceIdentifierArgsForCall, struct {
 	}{})
+	stub := fake.InstanceIdentifierStub
+	fakeReturns := fake.instanceIdentifierReturns
 	fake.recordInvocation("InstanceIdentifier", []interface{}{})
 	fake.instanceIdentifierMutex.Unlock()
-	if fake.InstanceIdentifierStub != nil {
-		return fake.InstanceIdentifierStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.instanceIdentifierReturns
 	return fakeReturns.result1
 }
 
@@ -738,15 +748,16 @@ func (fake *FakeJob) Name() string {
 	ret, specificReturn := fake.nameReturnsOnCall[len(fake.nameArgsForCall)]
 	fake.nameArgsForCall = append(fake.nameArgsForCall, struct {
 	}{})
+	stub := fake.NameStub
+	fakeReturns := fake.nameReturns
 	fake.recordInvocation("Name", []interface{}{})
 	fake.nameMutex.Unlock()
-	if fake.NameStub != nil {
-		return fake.NameStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.nameReturns
 	return fakeReturns.result1
 }
 
@@ -791,15 +802,16 @@ func (fake *FakeJob) PostBackupUnlock(arg1 bool) error {
 	fake.postBackupUnlockArgsForCall = append(fake.postBackupUnlockArgsForCall, struct {
 		arg1 bool
 	}{arg1})
+	stub := fake.PostBackupUnlockStub
+	fakeReturns := fake.postBackupUnlockReturns
 	fake.recordInvocation("PostBackupUnlock", []interface{}{arg1})
 	fake.postBackupUnlockMutex.Unlock()
-	if fake.PostBackupUnlockStub != nil {
-		return fake.PostBackupUnlockStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.postBackupUnlockReturns
 	return fakeReturns.result1
 }
 
@@ -850,15 +862,16 @@ func (fake *FakeJob) PostRestoreUnlock() error {
 	ret, specificReturn := fake.postRestoreUnlockReturnsOnCall[len(fake.postRestoreUnlockArgsForCall)]
 	fake.postRestoreUnlockArgsForCall = append(fake.postRestoreUnlockArgsForCall, struct {
 	}{})
+	stub := fake.PostRestoreUnlockStub
+	fakeReturns := fake.postRestoreUnlockReturns
 	fake.recordInvocation("PostRestoreUnlock", []interface{}{})
 	fake.postRestoreUnlockMutex.Unlock()
-	if fake.PostRestoreUnlockStub != nil {
-		return fake.PostRestoreUnlockStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.postRestoreUnlockReturns
 	return fakeReturns.result1
 }
 
@@ -902,15 +915,16 @@ func (fake *FakeJob) PreBackupLock() error {
 	ret, specificReturn := fake.preBackupLockReturnsOnCall[len(fake.preBackupLockArgsForCall)]
 	fake.preBackupLockArgsForCall = append(fake.preBackupLockArgsForCall, struct {
 	}{})
+	stub := fake.PreBackupLockStub
+	fakeReturns := fake.preBackupLockReturns
 	fake.recordInvocation("PreBackupLock", []interface{}{})
 	fake.preBackupLockMutex.Unlock()
-	if fake.PreBackupLockStub != nil {
-		return fake.PreBackupLockStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.preBackupLockReturns
 	return fakeReturns.result1
 }
 
@@ -954,15 +968,16 @@ func (fake *FakeJob) PreRestoreLock() error {
 	ret, specificReturn := fake.preRestoreLockReturnsOnCall[len(fake.preRestoreLockArgsForCall)]
 	fake.preRestoreLockArgsForCall = append(fake.preRestoreLockArgsForCall, struct {
 	}{})
+	stub := fake.PreRestoreLockStub
+	fakeReturns := fake.preRestoreLockReturns
 	fake.recordInvocation("PreRestoreLock", []interface{}{})
 	fake.preRestoreLockMutex.Unlock()
-	if fake.PreRestoreLockStub != nil {
-		return fake.PreRestoreLockStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.preRestoreLockReturns
 	return fakeReturns.result1
 }
 
@@ -1006,15 +1021,16 @@ func (fake *FakeJob) Release() string {
 	ret, specificReturn := fake.releaseReturnsOnCall[len(fake.releaseArgsForCall)]
 	fake.releaseArgsForCall = append(fake.releaseArgsForCall, struct {
 	}{})
+	stub := fake.ReleaseStub
+	fakeReturns := fake.releaseReturns
 	fake.recordInvocation("Release", []interface{}{})
 	fake.releaseMutex.Unlock()
-	if fake.ReleaseStub != nil {
-		return fake.ReleaseStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.releaseReturns
 	return fakeReturns.result1
 }
 
@@ -1058,15 +1074,16 @@ func (fake *FakeJob) Restore() error {
 	ret, specificReturn := fake.restoreReturnsOnCall[len(fake.restoreArgsForCall)]
 	fake.restoreArgsForCall = append(fake.restoreArgsForCall, struct {
 	}{})
+	stub := fake.RestoreStub
+	fakeReturns := fake.restoreReturns
 	fake.recordInvocation("Restore", []interface{}{})
 	fake.restoreMutex.Unlock()
-	if fake.RestoreStub != nil {
-		return fake.RestoreStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.restoreReturns
 	return fakeReturns.result1
 }
 
@@ -1110,15 +1127,16 @@ func (fake *FakeJob) RestoreArtifactDirectory() string {
 	ret, specificReturn := fake.restoreArtifactDirectoryReturnsOnCall[len(fake.restoreArtifactDirectoryArgsForCall)]
 	fake.restoreArtifactDirectoryArgsForCall = append(fake.restoreArtifactDirectoryArgsForCall, struct {
 	}{})
+	stub := fake.RestoreArtifactDirectoryStub
+	fakeReturns := fake.restoreArtifactDirectoryReturns
 	fake.recordInvocation("RestoreArtifactDirectory", []interface{}{})
 	fake.restoreArtifactDirectoryMutex.Unlock()
-	if fake.RestoreArtifactDirectoryStub != nil {
-		return fake.RestoreArtifactDirectoryStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.restoreArtifactDirectoryReturns
 	return fakeReturns.result1
 }
 
@@ -1162,15 +1180,16 @@ func (fake *FakeJob) RestoreArtifactName() string {
 	ret, specificReturn := fake.restoreArtifactNameReturnsOnCall[len(fake.restoreArtifactNameArgsForCall)]
 	fake.restoreArtifactNameArgsForCall = append(fake.restoreArtifactNameArgsForCall, struct {
 	}{})
+	stub := fake.RestoreArtifactNameStub
+	fakeReturns := fake.restoreArtifactNameReturns
 	fake.recordInvocation("RestoreArtifactName", []interface{}{})
 	fake.restoreArtifactNameMutex.Unlock()
-	if fake.RestoreArtifactNameStub != nil {
-		return fake.RestoreArtifactNameStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.restoreArtifactNameReturns
 	return fakeReturns.result1
 }
 
@@ -1214,15 +1233,16 @@ func (fake *FakeJob) RestoreShouldBeLockedBefore() []orchestrator.JobSpecifier {
 	ret, specificReturn := fake.restoreShouldBeLockedBeforeReturnsOnCall[len(fake.restoreShouldBeLockedBeforeArgsForCall)]
 	fake.restoreShouldBeLockedBeforeArgsForCall = append(fake.restoreShouldBeLockedBeforeArgsForCall, struct {
 	}{})
+	stub := fake.RestoreShouldBeLockedBeforeStub
+	fakeReturns := fake.restoreShouldBeLockedBeforeReturns
 	fake.recordInvocation("RestoreShouldBeLockedBefore", []interface{}{})
 	fake.restoreShouldBeLockedBeforeMutex.Unlock()
-	if fake.RestoreShouldBeLockedBeforeStub != nil {
-		return fake.RestoreShouldBeLockedBeforeStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.restoreShouldBeLockedBeforeReturns
 	return fakeReturns.result1
 }
 

--- a/orchestrator/fakes/fake_lock_orderer.go
+++ b/orchestrator/fakes/fake_lock_orderer.go
@@ -36,15 +36,16 @@ func (fake *FakeLockOrderer) Order(arg1 []orchestrator.Job) ([][]orchestrator.Jo
 	fake.orderArgsForCall = append(fake.orderArgsForCall, struct {
 		arg1 []orchestrator.Job
 	}{arg1Copy})
+	stub := fake.OrderStub
+	fakeReturns := fake.orderReturns
 	fake.recordInvocation("Order", []interface{}{arg1Copy})
 	fake.orderMutex.Unlock()
-	if fake.OrderStub != nil {
-		return fake.OrderStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.orderReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/orchestrator/fakes/fake_logger.go
+++ b/orchestrator/fakes/fake_logger.go
@@ -47,9 +47,10 @@ func (fake *FakeLogger) Debug(arg1 string, arg2 string, arg3 ...interface{}) {
 		arg2 string
 		arg3 []interface{}
 	}{arg1, arg2, arg3})
+	stub := fake.DebugStub
 	fake.recordInvocation("Debug", []interface{}{arg1, arg2, arg3})
 	fake.debugMutex.Unlock()
-	if fake.DebugStub != nil {
+	if stub != nil {
 		fake.DebugStub(arg1, arg2, arg3...)
 	}
 }
@@ -80,9 +81,10 @@ func (fake *FakeLogger) Error(arg1 string, arg2 string, arg3 ...interface{}) {
 		arg2 string
 		arg3 []interface{}
 	}{arg1, arg2, arg3})
+	stub := fake.ErrorStub
 	fake.recordInvocation("Error", []interface{}{arg1, arg2, arg3})
 	fake.errorMutex.Unlock()
-	if fake.ErrorStub != nil {
+	if stub != nil {
 		fake.ErrorStub(arg1, arg2, arg3...)
 	}
 }
@@ -113,9 +115,10 @@ func (fake *FakeLogger) Info(arg1 string, arg2 string, arg3 ...interface{}) {
 		arg2 string
 		arg3 []interface{}
 	}{arg1, arg2, arg3})
+	stub := fake.InfoStub
 	fake.recordInvocation("Info", []interface{}{arg1, arg2, arg3})
 	fake.infoMutex.Unlock()
-	if fake.InfoStub != nil {
+	if stub != nil {
 		fake.InfoStub(arg1, arg2, arg3...)
 	}
 }
@@ -146,9 +149,10 @@ func (fake *FakeLogger) Warn(arg1 string, arg2 string, arg3 ...interface{}) {
 		arg2 string
 		arg3 []interface{}
 	}{arg1, arg2, arg3})
+	stub := fake.WarnStub
 	fake.recordInvocation("Warn", []interface{}{arg1, arg2, arg3})
 	fake.warnMutex.Unlock()
-	if fake.WarnStub != nil {
+	if stub != nil {
 		fake.WarnStub(arg1, arg2, arg3...)
 	}
 }

--- a/readwriter/fakes/fake_logger.go
+++ b/readwriter/fakes/fake_logger.go
@@ -26,9 +26,10 @@ func (fake *FakeLogger) Info(arg1 string, arg2 string, arg3 ...interface{}) {
 		arg2 string
 		arg3 []interface{}
 	}{arg1, arg2, arg3})
+	stub := fake.InfoStub
 	fake.recordInvocation("Info", []interface{}{arg1, arg2, arg3})
 	fake.infoMutex.Unlock()
-	if fake.InfoStub != nil {
+	if stub != nil {
 		fake.InfoStub(arg1, arg2, arg3...)
 	}
 }

--- a/readwriter/fakes/fake_readwriter.go
+++ b/readwriter/fakes/fake_readwriter.go
@@ -48,15 +48,16 @@ func (fake *FakeReadWriter) Read(arg1 []byte) (int, error) {
 	fake.readArgsForCall = append(fake.readArgsForCall, struct {
 		arg1 []byte
 	}{arg1Copy})
+	stub := fake.ReadStub
+	fakeReturns := fake.readReturns
 	fake.recordInvocation("Read", []interface{}{arg1Copy})
 	fake.readMutex.Unlock()
-	if fake.ReadStub != nil {
-		return fake.ReadStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.readReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -116,15 +117,16 @@ func (fake *FakeReadWriter) Write(arg1 []byte) (int, error) {
 	fake.writeArgsForCall = append(fake.writeArgsForCall, struct {
 		arg1 []byte
 	}{arg1Copy})
+	stub := fake.WriteStub
+	fakeReturns := fake.writeReturns
 	fake.recordInvocation("Write", []interface{}{arg1Copy})
 	fake.writeMutex.Unlock()
-	if fake.WriteStub != nil {
-		return fake.WriteStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.writeReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/ssh/fakes/fake_logger.go
+++ b/ssh/fakes/fake_logger.go
@@ -40,9 +40,10 @@ func (fake *FakeLogger) Debug(arg1 string, arg2 string, arg3 ...interface{}) {
 		arg2 string
 		arg3 []interface{}
 	}{arg1, arg2, arg3})
+	stub := fake.DebugStub
 	fake.recordInvocation("Debug", []interface{}{arg1, arg2, arg3})
 	fake.debugMutex.Unlock()
-	if fake.DebugStub != nil {
+	if stub != nil {
 		fake.DebugStub(arg1, arg2, arg3...)
 	}
 }
@@ -73,9 +74,10 @@ func (fake *FakeLogger) Error(arg1 string, arg2 string, arg3 ...interface{}) {
 		arg2 string
 		arg3 []interface{}
 	}{arg1, arg2, arg3})
+	stub := fake.ErrorStub
 	fake.recordInvocation("Error", []interface{}{arg1, arg2, arg3})
 	fake.errorMutex.Unlock()
-	if fake.ErrorStub != nil {
+	if stub != nil {
 		fake.ErrorStub(arg1, arg2, arg3...)
 	}
 }
@@ -106,9 +108,10 @@ func (fake *FakeLogger) Warn(arg1 string, arg2 string, arg3 ...interface{}) {
 		arg2 string
 		arg3 []interface{}
 	}{arg1, arg2, arg3})
+	stub := fake.WarnStub
 	fake.recordInvocation("Warn", []interface{}{arg1, arg2, arg3})
 	fake.warnMutex.Unlock()
-	if fake.WarnStub != nil {
+	if stub != nil {
 		fake.WarnStub(arg1, arg2, arg3...)
 	}
 }

--- a/ssh/fakes/fake_opts_generator.go
+++ b/ssh/fakes/fake_opts_generator.go
@@ -35,15 +35,17 @@ func (fake *FakeSSHOptsGenerator) Spy(arg1 uuid.Generator) (director.SSHOpts, st
 	fake.argsForCall = append(fake.argsForCall, struct {
 		arg1 uuid.Generator
 	}{arg1})
+	stub := fake.Stub
+	returns := fake.returns
 	fake.recordInvocation("SSHOptsGenerator", []interface{}{arg1})
 	fake.mutex.Unlock()
-	if fake.Stub != nil {
-		return fake.Stub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	return fake.returns.result1, fake.returns.result2, fake.returns.result3
+	return returns.result1, returns.result2, returns.result3
 }
 
 func (fake *FakeSSHOptsGenerator) CallCount() int {

--- a/ssh/fakes/fake_remote_runner.go
+++ b/ssh/fakes/fake_remote_runner.go
@@ -130,18 +130,18 @@ type FakeRemoteRunner struct {
 		result1 string
 		result2 error
 	}
-	RunScriptWithEnvStub        func(string, map[string]string, string) (string, error)
-	runScriptWithEnvMutex       sync.RWMutex
-	runScriptWithEnvArgsForCall []struct {
+	RunScriptWithEnvGetStdoutStub        func(string, map[string]string, string) (string, error)
+	runScriptWithEnvGetStdoutMutex       sync.RWMutex
+	runScriptWithEnvGetStdoutArgsForCall []struct {
 		arg1 string
 		arg2 map[string]string
 		arg3 string
 	}
-	runScriptWithEnvReturns struct {
+	runScriptWithEnvGetStdoutReturns struct {
 		result1 string
 		result2 error
 	}
-	runScriptWithEnvReturnsOnCall map[int]struct {
+	runScriptWithEnvGetStdoutReturnsOnCall map[int]struct {
 		result1 string
 		result2 error
 	}
@@ -182,15 +182,16 @@ func (fake *FakeRemoteRunner) ArchiveAndDownload(arg1 string, arg2 io.Writer) er
 		arg1 string
 		arg2 io.Writer
 	}{arg1, arg2})
+	stub := fake.ArchiveAndDownloadStub
+	fakeReturns := fake.archiveAndDownloadReturns
 	fake.recordInvocation("ArchiveAndDownload", []interface{}{arg1, arg2})
 	fake.archiveAndDownloadMutex.Unlock()
-	if fake.ArchiveAndDownloadStub != nil {
-		return fake.ArchiveAndDownloadStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.archiveAndDownloadReturns
 	return fakeReturns.result1
 }
 
@@ -242,15 +243,16 @@ func (fake *FakeRemoteRunner) ChecksumDirectory(arg1 string) (map[string]string,
 	fake.checksumDirectoryArgsForCall = append(fake.checksumDirectoryArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.ChecksumDirectoryStub
+	fakeReturns := fake.checksumDirectoryReturns
 	fake.recordInvocation("ChecksumDirectory", []interface{}{arg1})
 	fake.checksumDirectoryMutex.Unlock()
-	if fake.ChecksumDirectoryStub != nil {
-		return fake.ChecksumDirectoryStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.checksumDirectoryReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -304,15 +306,16 @@ func (fake *FakeRemoteRunner) ConnectedUsername() string {
 	ret, specificReturn := fake.connectedUsernameReturnsOnCall[len(fake.connectedUsernameArgsForCall)]
 	fake.connectedUsernameArgsForCall = append(fake.connectedUsernameArgsForCall, struct {
 	}{})
+	stub := fake.ConnectedUsernameStub
+	fakeReturns := fake.connectedUsernameReturns
 	fake.recordInvocation("ConnectedUsername", []interface{}{})
 	fake.connectedUsernameMutex.Unlock()
-	if fake.ConnectedUsernameStub != nil {
-		return fake.ConnectedUsernameStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.connectedUsernameReturns
 	return fakeReturns.result1
 }
 
@@ -357,15 +360,16 @@ func (fake *FakeRemoteRunner) CreateDirectory(arg1 string) error {
 	fake.createDirectoryArgsForCall = append(fake.createDirectoryArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.CreateDirectoryStub
+	fakeReturns := fake.createDirectoryReturns
 	fake.recordInvocation("CreateDirectory", []interface{}{arg1})
 	fake.createDirectoryMutex.Unlock()
-	if fake.CreateDirectoryStub != nil {
-		return fake.CreateDirectoryStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.createDirectoryReturns
 	return fakeReturns.result1
 }
 
@@ -417,15 +421,16 @@ func (fake *FakeRemoteRunner) DirectoryExists(arg1 string) (bool, error) {
 	fake.directoryExistsArgsForCall = append(fake.directoryExistsArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.DirectoryExistsStub
+	fakeReturns := fake.directoryExistsReturns
 	fake.recordInvocation("DirectoryExists", []interface{}{arg1})
 	fake.directoryExistsMutex.Unlock()
-	if fake.DirectoryExistsStub != nil {
-		return fake.DirectoryExistsStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.directoryExistsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -481,15 +486,16 @@ func (fake *FakeRemoteRunner) ExtractAndUpload(arg1 io.Reader, arg2 string) erro
 		arg1 io.Reader
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.ExtractAndUploadStub
+	fakeReturns := fake.extractAndUploadReturns
 	fake.recordInvocation("ExtractAndUpload", []interface{}{arg1, arg2})
 	fake.extractAndUploadMutex.Unlock()
-	if fake.ExtractAndUploadStub != nil {
-		return fake.ExtractAndUploadStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.extractAndUploadReturns
 	return fakeReturns.result1
 }
 
@@ -541,15 +547,16 @@ func (fake *FakeRemoteRunner) FindFiles(arg1 string) ([]string, error) {
 	fake.findFilesArgsForCall = append(fake.findFilesArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.FindFilesStub
+	fakeReturns := fake.findFilesReturns
 	fake.recordInvocation("FindFiles", []interface{}{arg1})
 	fake.findFilesMutex.Unlock()
-	if fake.FindFilesStub != nil {
-		return fake.FindFilesStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.findFilesReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -603,15 +610,16 @@ func (fake *FakeRemoteRunner) IsWindows() (bool, error) {
 	ret, specificReturn := fake.isWindowsReturnsOnCall[len(fake.isWindowsArgsForCall)]
 	fake.isWindowsArgsForCall = append(fake.isWindowsArgsForCall, struct {
 	}{})
+	stub := fake.IsWindowsStub
+	fakeReturns := fake.isWindowsReturns
 	fake.recordInvocation("IsWindows", []interface{}{})
 	fake.isWindowsMutex.Unlock()
-	if fake.IsWindowsStub != nil {
-		return fake.IsWindowsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.isWindowsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -659,15 +667,16 @@ func (fake *FakeRemoteRunner) RemoveDirectory(arg1 string) error {
 	fake.removeDirectoryArgsForCall = append(fake.removeDirectoryArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.RemoveDirectoryStub
+	fakeReturns := fake.removeDirectoryReturns
 	fake.recordInvocation("RemoveDirectory", []interface{}{arg1})
 	fake.removeDirectoryMutex.Unlock()
-	if fake.RemoveDirectoryStub != nil {
-		return fake.RemoveDirectoryStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.removeDirectoryReturns
 	return fakeReturns.result1
 }
 
@@ -720,15 +729,16 @@ func (fake *FakeRemoteRunner) RunScript(arg1 string, arg2 string) (string, error
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.RunScriptStub
+	fakeReturns := fake.runScriptReturns
 	fake.recordInvocation("RunScript", []interface{}{arg1, arg2})
 	fake.runScriptMutex.Unlock()
-	if fake.RunScriptStub != nil {
-		return fake.RunScriptStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.runScriptReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -777,66 +787,67 @@ func (fake *FakeRemoteRunner) RunScriptReturnsOnCall(i int, result1 string, resu
 	}{result1, result2}
 }
 
-func (fake *FakeRemoteRunner) RunScriptWithEnv(arg1 string, arg2 map[string]string, arg3 string) (string, error) {
-	fake.runScriptWithEnvMutex.Lock()
-	ret, specificReturn := fake.runScriptWithEnvReturnsOnCall[len(fake.runScriptWithEnvArgsForCall)]
-	fake.runScriptWithEnvArgsForCall = append(fake.runScriptWithEnvArgsForCall, struct {
+func (fake *FakeRemoteRunner) RunScriptWithEnvGetStdout(arg1 string, arg2 map[string]string, arg3 string) (string, error) {
+	fake.runScriptWithEnvGetStdoutMutex.Lock()
+	ret, specificReturn := fake.runScriptWithEnvGetStdoutReturnsOnCall[len(fake.runScriptWithEnvGetStdoutArgsForCall)]
+	fake.runScriptWithEnvGetStdoutArgsForCall = append(fake.runScriptWithEnvGetStdoutArgsForCall, struct {
 		arg1 string
 		arg2 map[string]string
 		arg3 string
 	}{arg1, arg2, arg3})
-	fake.recordInvocation("RunScriptWithEnv", []interface{}{arg1, arg2, arg3})
-	fake.runScriptWithEnvMutex.Unlock()
-	if fake.RunScriptWithEnvStub != nil {
-		return fake.RunScriptWithEnvStub(arg1, arg2, arg3)
+	stub := fake.RunScriptWithEnvGetStdoutStub
+	fakeReturns := fake.runScriptWithEnvGetStdoutReturns
+	fake.recordInvocation("RunScriptWithEnvGetStdout", []interface{}{arg1, arg2, arg3})
+	fake.runScriptWithEnvGetStdoutMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.runScriptWithEnvReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
-func (fake *FakeRemoteRunner) RunScriptWithEnvCallCount() int {
-	fake.runScriptWithEnvMutex.RLock()
-	defer fake.runScriptWithEnvMutex.RUnlock()
-	return len(fake.runScriptWithEnvArgsForCall)
+func (fake *FakeRemoteRunner) RunScriptWithEnvGetStdoutCallCount() int {
+	fake.runScriptWithEnvGetStdoutMutex.RLock()
+	defer fake.runScriptWithEnvGetStdoutMutex.RUnlock()
+	return len(fake.runScriptWithEnvGetStdoutArgsForCall)
 }
 
-func (fake *FakeRemoteRunner) RunScriptWithEnvCalls(stub func(string, map[string]string, string) (string, error)) {
-	fake.runScriptWithEnvMutex.Lock()
-	defer fake.runScriptWithEnvMutex.Unlock()
-	fake.RunScriptWithEnvStub = stub
+func (fake *FakeRemoteRunner) RunScriptWithEnvGetStdoutCalls(stub func(string, map[string]string, string) (string, error)) {
+	fake.runScriptWithEnvGetStdoutMutex.Lock()
+	defer fake.runScriptWithEnvGetStdoutMutex.Unlock()
+	fake.RunScriptWithEnvGetStdoutStub = stub
 }
 
-func (fake *FakeRemoteRunner) RunScriptWithEnvArgsForCall(i int) (string, map[string]string, string) {
-	fake.runScriptWithEnvMutex.RLock()
-	defer fake.runScriptWithEnvMutex.RUnlock()
-	argsForCall := fake.runScriptWithEnvArgsForCall[i]
+func (fake *FakeRemoteRunner) RunScriptWithEnvGetStdoutArgsForCall(i int) (string, map[string]string, string) {
+	fake.runScriptWithEnvGetStdoutMutex.RLock()
+	defer fake.runScriptWithEnvGetStdoutMutex.RUnlock()
+	argsForCall := fake.runScriptWithEnvGetStdoutArgsForCall[i]
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
-func (fake *FakeRemoteRunner) RunScriptWithEnvReturns(result1 string, result2 error) {
-	fake.runScriptWithEnvMutex.Lock()
-	defer fake.runScriptWithEnvMutex.Unlock()
-	fake.RunScriptWithEnvStub = nil
-	fake.runScriptWithEnvReturns = struct {
+func (fake *FakeRemoteRunner) RunScriptWithEnvGetStdoutReturns(result1 string, result2 error) {
+	fake.runScriptWithEnvGetStdoutMutex.Lock()
+	defer fake.runScriptWithEnvGetStdoutMutex.Unlock()
+	fake.RunScriptWithEnvGetStdoutStub = nil
+	fake.runScriptWithEnvGetStdoutReturns = struct {
 		result1 string
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeRemoteRunner) RunScriptWithEnvReturnsOnCall(i int, result1 string, result2 error) {
-	fake.runScriptWithEnvMutex.Lock()
-	defer fake.runScriptWithEnvMutex.Unlock()
-	fake.RunScriptWithEnvStub = nil
-	if fake.runScriptWithEnvReturnsOnCall == nil {
-		fake.runScriptWithEnvReturnsOnCall = make(map[int]struct {
+func (fake *FakeRemoteRunner) RunScriptWithEnvGetStdoutReturnsOnCall(i int, result1 string, result2 error) {
+	fake.runScriptWithEnvGetStdoutMutex.Lock()
+	defer fake.runScriptWithEnvGetStdoutMutex.Unlock()
+	fake.RunScriptWithEnvGetStdoutStub = nil
+	if fake.runScriptWithEnvGetStdoutReturnsOnCall == nil {
+		fake.runScriptWithEnvGetStdoutReturnsOnCall = make(map[int]struct {
 			result1 string
 			result2 error
 		})
 	}
-	fake.runScriptWithEnvReturnsOnCall[i] = struct {
+	fake.runScriptWithEnvGetStdoutReturnsOnCall[i] = struct {
 		result1 string
 		result2 error
 	}{result1, result2}
@@ -848,15 +859,16 @@ func (fake *FakeRemoteRunner) SizeInBytes(arg1 string) (int, error) {
 	fake.sizeInBytesArgsForCall = append(fake.sizeInBytesArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.SizeInBytesStub
+	fakeReturns := fake.sizeInBytesReturns
 	fake.recordInvocation("SizeInBytes", []interface{}{arg1})
 	fake.sizeInBytesMutex.Unlock()
-	if fake.SizeInBytesStub != nil {
-		return fake.SizeInBytesStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.sizeInBytesReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -911,15 +923,16 @@ func (fake *FakeRemoteRunner) SizeOf(arg1 string) (string, error) {
 	fake.sizeOfArgsForCall = append(fake.sizeOfArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.SizeOfStub
+	fakeReturns := fake.sizeOfReturns
 	fake.recordInvocation("SizeOf", []interface{}{arg1})
 	fake.sizeOfMutex.Unlock()
-	if fake.SizeOfStub != nil {
-		return fake.SizeOfStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.sizeOfReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -991,8 +1004,8 @@ func (fake *FakeRemoteRunner) Invocations() map[string][][]interface{} {
 	defer fake.removeDirectoryMutex.RUnlock()
 	fake.runScriptMutex.RLock()
 	defer fake.runScriptMutex.RUnlock()
-	fake.runScriptWithEnvMutex.RLock()
-	defer fake.runScriptWithEnvMutex.RUnlock()
+	fake.runScriptWithEnvGetStdoutMutex.RLock()
+	defer fake.runScriptWithEnvGetStdoutMutex.RUnlock()
 	fake.sizeInBytesMutex.RLock()
 	defer fake.sizeInBytesMutex.RUnlock()
 	fake.sizeOfMutex.RLock()

--- a/ssh/fakes/fake_remote_runner.go
+++ b/ssh/fakes/fake_remote_runner.go
@@ -130,6 +130,19 @@ type FakeRemoteRunner struct {
 		result1 string
 		result2 error
 	}
+	RunScriptWithEnvStub        func(string, map[string]string, string) error
+	runScriptWithEnvMutex       sync.RWMutex
+	runScriptWithEnvArgsForCall []struct {
+		arg1 string
+		arg2 map[string]string
+		arg3 string
+	}
+	runScriptWithEnvReturns struct {
+		result1 error
+	}
+	runScriptWithEnvReturnsOnCall map[int]struct {
+		result1 error
+	}
 	RunScriptWithEnvGetStdoutStub        func(string, map[string]string, string) (string, error)
 	runScriptWithEnvGetStdoutMutex       sync.RWMutex
 	runScriptWithEnvGetStdoutArgsForCall []struct {
@@ -787,6 +800,69 @@ func (fake *FakeRemoteRunner) RunScriptReturnsOnCall(i int, result1 string, resu
 	}{result1, result2}
 }
 
+func (fake *FakeRemoteRunner) RunScriptWithEnv(arg1 string, arg2 map[string]string, arg3 string) error {
+	fake.runScriptWithEnvMutex.Lock()
+	ret, specificReturn := fake.runScriptWithEnvReturnsOnCall[len(fake.runScriptWithEnvArgsForCall)]
+	fake.runScriptWithEnvArgsForCall = append(fake.runScriptWithEnvArgsForCall, struct {
+		arg1 string
+		arg2 map[string]string
+		arg3 string
+	}{arg1, arg2, arg3})
+	stub := fake.RunScriptWithEnvStub
+	fakeReturns := fake.runScriptWithEnvReturns
+	fake.recordInvocation("RunScriptWithEnv", []interface{}{arg1, arg2, arg3})
+	fake.runScriptWithEnvMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeRemoteRunner) RunScriptWithEnvCallCount() int {
+	fake.runScriptWithEnvMutex.RLock()
+	defer fake.runScriptWithEnvMutex.RUnlock()
+	return len(fake.runScriptWithEnvArgsForCall)
+}
+
+func (fake *FakeRemoteRunner) RunScriptWithEnvCalls(stub func(string, map[string]string, string) error) {
+	fake.runScriptWithEnvMutex.Lock()
+	defer fake.runScriptWithEnvMutex.Unlock()
+	fake.RunScriptWithEnvStub = stub
+}
+
+func (fake *FakeRemoteRunner) RunScriptWithEnvArgsForCall(i int) (string, map[string]string, string) {
+	fake.runScriptWithEnvMutex.RLock()
+	defer fake.runScriptWithEnvMutex.RUnlock()
+	argsForCall := fake.runScriptWithEnvArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeRemoteRunner) RunScriptWithEnvReturns(result1 error) {
+	fake.runScriptWithEnvMutex.Lock()
+	defer fake.runScriptWithEnvMutex.Unlock()
+	fake.RunScriptWithEnvStub = nil
+	fake.runScriptWithEnvReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeRemoteRunner) RunScriptWithEnvReturnsOnCall(i int, result1 error) {
+	fake.runScriptWithEnvMutex.Lock()
+	defer fake.runScriptWithEnvMutex.Unlock()
+	fake.RunScriptWithEnvStub = nil
+	if fake.runScriptWithEnvReturnsOnCall == nil {
+		fake.runScriptWithEnvReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.runScriptWithEnvReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeRemoteRunner) RunScriptWithEnvGetStdout(arg1 string, arg2 map[string]string, arg3 string) (string, error) {
 	fake.runScriptWithEnvGetStdoutMutex.Lock()
 	ret, specificReturn := fake.runScriptWithEnvGetStdoutReturnsOnCall[len(fake.runScriptWithEnvGetStdoutArgsForCall)]
@@ -1004,6 +1080,8 @@ func (fake *FakeRemoteRunner) Invocations() map[string][][]interface{} {
 	defer fake.removeDirectoryMutex.RUnlock()
 	fake.runScriptMutex.RLock()
 	defer fake.runScriptMutex.RUnlock()
+	fake.runScriptWithEnvMutex.RLock()
+	defer fake.runScriptWithEnvMutex.RUnlock()
 	fake.runScriptWithEnvGetStdoutMutex.RLock()
 	defer fake.runScriptWithEnvGetStdoutMutex.RUnlock()
 	fake.sizeInBytesMutex.RLock()

--- a/ssh/fakes/fake_remote_runner_factory.go
+++ b/ssh/fakes/fake_remote_runner_factory.go
@@ -47,15 +47,17 @@ func (fake *FakeRemoteRunnerFactory) Spy(arg1 string, arg2 string, arg3 string, 
 		arg5 []string
 		arg6 ssh.Logger
 	}{arg1, arg2, arg3, arg4, arg5Copy, arg6})
+	stub := fake.Stub
+	returns := fake.returns
 	fake.recordInvocation("RemoteRunnerFactory", []interface{}{arg1, arg2, arg3, arg4, arg5Copy, arg6})
 	fake.mutex.Unlock()
-	if fake.Stub != nil {
-		return fake.Stub(arg1, arg2, arg3, arg4, arg5, arg6)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4, arg5, arg6)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.returns.result1, fake.returns.result2
+	return returns.result1, returns.result2
 }
 
 func (fake *FakeRemoteRunnerFactory) CallCount() int {

--- a/ssh/fakes/fake_ssh_connection.go
+++ b/ssh/fakes/fake_ssh_connection.go
@@ -80,15 +80,16 @@ func (fake *FakeSSHConnection) Run(arg1 string) ([]byte, []byte, int, error) {
 	fake.runArgsForCall = append(fake.runArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.RunStub
+	fakeReturns := fake.runReturns
 	fake.recordInvocation("Run", []interface{}{arg1})
 	fake.runMutex.Unlock()
-	if fake.RunStub != nil {
-		return fake.RunStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3, ret.result4
 	}
-	fakeReturns := fake.runReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3, fakeReturns.result4
 }
 
@@ -150,15 +151,16 @@ func (fake *FakeSSHConnection) Stream(arg1 string, arg2 io.Writer) ([]byte, int,
 		arg1 string
 		arg2 io.Writer
 	}{arg1, arg2})
+	stub := fake.StreamStub
+	fakeReturns := fake.streamReturns
 	fake.recordInvocation("Stream", []interface{}{arg1, arg2})
 	fake.streamMutex.Unlock()
-	if fake.StreamStub != nil {
-		return fake.StreamStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.streamReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -217,15 +219,16 @@ func (fake *FakeSSHConnection) StreamStdin(arg1 string, arg2 io.Reader) ([]byte,
 		arg1 string
 		arg2 io.Reader
 	}{arg1, arg2})
+	stub := fake.StreamStdinStub
+	fakeReturns := fake.streamStdinReturns
 	fake.recordInvocation("StreamStdin", []interface{}{arg1, arg2})
 	fake.streamStdinMutex.Unlock()
-	if fake.StreamStdinStub != nil {
-		return fake.StreamStdinStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3, ret.result4
 	}
-	fakeReturns := fake.streamStdinReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3, fakeReturns.result4
 }
 
@@ -285,15 +288,16 @@ func (fake *FakeSSHConnection) Username() string {
 	ret, specificReturn := fake.usernameReturnsOnCall[len(fake.usernameArgsForCall)]
 	fake.usernameArgsForCall = append(fake.usernameArgsForCall, struct {
 	}{})
+	stub := fake.UsernameStub
+	fakeReturns := fake.usernameReturns
 	fake.recordInvocation("Username", []interface{}{})
 	fake.usernameMutex.Unlock()
-	if fake.UsernameStub != nil {
-		return fake.UsernameStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.usernameReturns
 	return fakeReturns.result1
 }
 

--- a/ssh/fakes/fake_ssh_session.go
+++ b/ssh/fakes/fake_ssh_session.go
@@ -53,15 +53,16 @@ func (fake *FakeSSHSession) Close() error {
 	ret, specificReturn := fake.closeReturnsOnCall[len(fake.closeArgsForCall)]
 	fake.closeArgsForCall = append(fake.closeArgsForCall, struct {
 	}{})
+	stub := fake.CloseStub
+	fakeReturns := fake.closeReturns
 	fake.recordInvocation("Close", []interface{}{})
 	fake.closeMutex.Unlock()
-	if fake.CloseStub != nil {
-		return fake.CloseStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.closeReturns
 	return fakeReturns.result1
 }
 
@@ -106,15 +107,16 @@ func (fake *FakeSSHSession) Run(arg1 string) error {
 	fake.runArgsForCall = append(fake.runArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.RunStub
+	fakeReturns := fake.runReturns
 	fake.recordInvocation("Run", []interface{}{arg1})
 	fake.runMutex.Unlock()
-	if fake.RunStub != nil {
-		return fake.RunStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.runReturns
 	return fakeReturns.result1
 }
 
@@ -173,15 +175,16 @@ func (fake *FakeSSHSession) SendRequest(arg1 string, arg2 bool, arg3 []byte) (bo
 		arg2 bool
 		arg3 []byte
 	}{arg1, arg2, arg3Copy})
+	stub := fake.SendRequestStub
+	fakeReturns := fake.sendRequestReturns
 	fake.recordInvocation("SendRequest", []interface{}{arg1, arg2, arg3Copy})
 	fake.sendRequestMutex.Unlock()
-	if fake.SendRequestStub != nil {
-		return fake.SendRequestStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.sendRequestReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/ssh/remote_runner.go
+++ b/ssh/remote_runner.go
@@ -24,6 +24,7 @@ type RemoteRunner interface {
 	ChecksumDirectory(path string) (map[string]string, error)
 	RunScript(path, label string) (string, error)
 	RunScriptWithEnvGetStdout(path string, env map[string]string, label string) (string, error)
+	RunScriptWithEnv(path string, env map[string]string, label string) error
 	FindFiles(pattern string) ([]string, error)
 	IsWindows() (bool, error)
 }
@@ -117,6 +118,13 @@ func (r SshRemoteRunner) RunScriptWithEnvGetStdout(path string, env map[string]s
 	}
 
 	return r.runOnInstanceWithLabelGetStdout("sudo "+varsList+path, label)
+}
+
+// RunScriptWithEnv is a more memory-efficient version of
+// RunScriptWithEnvGetStdout , which doesn't buffer or return the
+// contents of stdout.
+func (r SshRemoteRunner) RunScriptWithEnv(path string, env map[string]string, label string) error {
+	return nil
 }
 
 func (r SshRemoteRunner) FindFiles(pattern string) ([]string, error) {

--- a/ssh/remote_runner.go
+++ b/ssh/remote_runner.go
@@ -116,7 +116,7 @@ func (r SshRemoteRunner) RunScriptWithEnvGetStdout(path string, env map[string]s
 		varsList = varsList + varName + "=" + value + " "
 	}
 
-	return r.runOnInstanceWithLabel("sudo "+varsList+path, label)
+	return r.runOnInstanceWithLabelGetStdout("sudo "+varsList+path, label)
 }
 
 func (r SshRemoteRunner) FindFiles(pattern string) ([]string, error) {
@@ -151,10 +151,10 @@ func (r SshRemoteRunner) IsWindows() (bool, error) {
 }
 
 func (r SshRemoteRunner) runOnInstance(cmd string) (string, error) {
-	return r.runOnInstanceWithLabel(cmd, "")
+	return r.runOnInstanceWithLabelGetStdout(cmd, "")
 }
 
-func (r SshRemoteRunner) runOnInstanceWithLabel(cmd, label string) (string, error) {
+func (r SshRemoteRunner) runOnInstanceWithLabelGetStdout(cmd, label string) (string, error) {
 	stdout, stderr, exitCode, runErr := r.connection.Run(cmd)
 
 	err := r.logAndCheckErrors(stdout, stderr, exitCode, runErr, label)

--- a/ssh/remote_runner.go
+++ b/ssh/remote_runner.go
@@ -129,7 +129,11 @@ func (r SshRemoteRunner) RunScriptWithEnv(path string, env map[string]string, la
 		varsList = varsList + varName + "=" + value + " "
 	}
 
-	stderr, exitCode, _ := r.connection.Stream("sudo " + varsList + path, io.Discard)
+	stderr, exitCode, err := r.connection.Stream("sudo " + varsList + path, io.Discard)
+
+	if err != nil {
+		return errors.Wrap(err, "connection.Stream failed")
+	}
 
 	if exitCode != 0 {
 		return exitError(stderr, exitCode)

--- a/ssh/remote_runner.go
+++ b/ssh/remote_runner.go
@@ -124,7 +124,12 @@ func (r SshRemoteRunner) RunScriptWithEnvGetStdout(path string, env map[string]s
 // RunScriptWithEnvGetStdout , which doesn't buffer or return the
 // contents of stdout.
 func (r SshRemoteRunner) RunScriptWithEnv(path string, env map[string]string, label string) error {
-	stderr, exitCode, _ := r.connection.Stream("sudo "+path, io.Discard)
+	var varsList = ""
+	for varName, value := range env {
+		varsList = varsList + varName + "=" + value + " "
+	}
+
+	stderr, exitCode, _ := r.connection.Stream("sudo " + varsList + path, io.Discard)
 
 	if exitCode != 0 {
 		return exitError(stderr, exitCode)

--- a/ssh/remote_runner.go
+++ b/ssh/remote_runner.go
@@ -23,7 +23,7 @@ type RemoteRunner interface {
 	SizeInBytes(path string) (int, error)
 	ChecksumDirectory(path string) (map[string]string, error)
 	RunScript(path, label string) (string, error)
-	RunScriptWithEnv(path string, env map[string]string, label string) (string, error)
+	RunScriptWithEnvGetStdout(path string, env map[string]string, label string) (string, error)
 	FindFiles(pattern string) ([]string, error)
 	IsWindows() (bool, error)
 }
@@ -107,10 +107,10 @@ func (r SshRemoteRunner) ChecksumDirectory(path string) (map[string]string, erro
 }
 
 func (r SshRemoteRunner) RunScript(path, label string) (string, error) {
-	return r.RunScriptWithEnv(path, map[string]string{}, label)
+	return r.RunScriptWithEnvGetStdout(path, map[string]string{}, label)
 }
 
-func (r SshRemoteRunner) RunScriptWithEnv(path string, env map[string]string, label string) (string, error) {
+func (r SshRemoteRunner) RunScriptWithEnvGetStdout(path string, env map[string]string, label string) (string, error) {
 	var varsList = ""
 	for varName, value := range env {
 		varsList = varsList + varName + "=" + value + " "

--- a/ssh/remote_runner.go
+++ b/ssh/remote_runner.go
@@ -124,6 +124,12 @@ func (r SshRemoteRunner) RunScriptWithEnvGetStdout(path string, env map[string]s
 // RunScriptWithEnvGetStdout , which doesn't buffer or return the
 // contents of stdout.
 func (r SshRemoteRunner) RunScriptWithEnv(path string, env map[string]string, label string) error {
+	stderr, exitCode, _ := r.connection.Stream("sudo "+path, io.Discard)
+
+	if exitCode != 0 {
+		return exitError(stderr, exitCode)
+	}
+
 	return nil
 }
 

--- a/ssh/remote_runner_test.go
+++ b/ssh/remote_runner_test.go
@@ -367,7 +367,7 @@ var _ = Describe("SshRemoteRunner", func() {
 
 	Describe("RunScriptWithEnv", func() {
 		When("the script exists", func() {
-			It("runs the script with the specified env variables", func() {
+			It("runs the script successfully", func() {
 
 				runCommand("echo 'true' > /tmp/example-script")
 				makeAccessibleOnlyByRoot("/tmp/example-script")
@@ -394,6 +394,17 @@ var _ = Describe("SshRemoteRunner", func() {
 				err := sshRemoteRunner.RunScriptWithEnv("/tmp/example-script", map[string]string{}, "")
 
 				Expect(err).To(MatchError(ContainSubstring("command not found")))
+			})
+		})
+
+		When("the ssh connection fails", func() {
+			BeforeEach(func() {
+				destroyInstance(testInstance)
+			})
+
+			It("returns an error", func() {
+				err := sshRemoteRunner.RunScriptWithEnv("whatever", map[string]string{}, "")
+				Expect(err).To(MatchError(ContainSubstring("ssh.Dial failed")))
 			})
 		})
 	})

--- a/ssh/remote_runner_test.go
+++ b/ssh/remote_runner_test.go
@@ -315,7 +315,7 @@ var _ = Describe("SshRemoteRunner", func() {
 		})
 	})
 
-	Describe("RunScriptWithEnv", func() {
+	Describe("RunScriptWithEnvGetStdout", func() {
 		Context("When the script exists", func() {
 			It("runs the script with the specified env variables", func() {
 
@@ -361,6 +361,20 @@ var _ = Describe("SshRemoteRunner", func() {
 			It("returns an error", func() {
 				_, err := sshRemoteRunner.RunScriptWithEnvGetStdout("whatever", map[string]string{}, "")
 				Expect(err).To(MatchError(ContainSubstring("ssh.Dial failed")))
+			})
+		})
+	})
+
+	Describe("RunScriptWithEnv", func() {
+		Context("When the script exists", func() {
+			It("runs the script with the specified env variables", func() {
+
+				runCommand("echo 'true' > /tmp/example-script")
+				makeAccessibleOnlyByRoot("/tmp/example-script")
+
+				err := sshRemoteRunner.RunScriptWithEnv("/tmp/example-script", map[string]string{}, "")
+
+				Expect(err).NotTo(HaveOccurred())
 			})
 		})
 	})

--- a/ssh/remote_runner_test.go
+++ b/ssh/remote_runner_test.go
@@ -322,7 +322,7 @@ var _ = Describe("SshRemoteRunner", func() {
 				runCommand("echo 'env' > /tmp/example-script")
 				makeAccessibleOnlyByRoot("/tmp/example-script")
 
-				stdout, err := sshRemoteRunner.RunScriptWithEnv("/tmp/example-script", map[string]string{"env1": "foo", "env2": "bar"}, "")
+				stdout, err := sshRemoteRunner.RunScriptWithEnvGetStdout("/tmp/example-script", map[string]string{"env1": "foo", "env2": "bar"}, "")
 
 				Expect(err).NotTo(HaveOccurred())
 
@@ -335,7 +335,7 @@ var _ = Describe("SshRemoteRunner", func() {
 
 		Context("when the script is not there", func() {
 			It("returns a helpful error", func() {
-				_, err := sshRemoteRunner.RunScriptWithEnv("/tmp/example-script", map[string]string{"env1": "foo", "env2": "bar"}, "")
+				_, err := sshRemoteRunner.RunScriptWithEnvGetStdout("/tmp/example-script", map[string]string{"env1": "foo", "env2": "bar"}, "")
 
 				Expect(err).To(MatchError(ContainSubstring("command not found")))
 
@@ -347,7 +347,7 @@ var _ = Describe("SshRemoteRunner", func() {
 				runCommand("echo '>&2 echo example script has errorred; exit 12' > /tmp/example-script")
 				runCommand("chmod +x /tmp/example-script")
 
-				_, err := sshRemoteRunner.RunScriptWithEnv("/tmp/example-script", map[string]string{"env1": "foo", "env2": "bar"}, "")
+				_, err := sshRemoteRunner.RunScriptWithEnvGetStdout("/tmp/example-script", map[string]string{"env1": "foo", "env2": "bar"}, "")
 
 				Expect(err).To(MatchError(ContainSubstring("example script has errorred - exit code 12")))
 
@@ -359,7 +359,7 @@ var _ = Describe("SshRemoteRunner", func() {
 			})
 
 			It("returns an error", func() {
-				_, err := sshRemoteRunner.RunScriptWithEnv("whatever", map[string]string{}, "")
+				_, err := sshRemoteRunner.RunScriptWithEnvGetStdout("whatever", map[string]string{}, "")
 				Expect(err).To(MatchError(ContainSubstring("ssh.Dial failed")))
 			})
 		})

--- a/ssh/remote_runner_test.go
+++ b/ssh/remote_runner_test.go
@@ -366,7 +366,7 @@ var _ = Describe("SshRemoteRunner", func() {
 	})
 
 	Describe("RunScriptWithEnv", func() {
-		Context("When the script exists", func() {
+		When("the script exists", func() {
 			It("runs the script with the specified env variables", func() {
 
 				runCommand("echo 'true' > /tmp/example-script")
@@ -376,8 +376,20 @@ var _ = Describe("SshRemoteRunner", func() {
 
 				Expect(err).NotTo(HaveOccurred())
 			})
+
+			When("we provide environment variables to the script", func() {
+				It("can access those environment variables", func() {
+					runCommand("echo '[ \"$ENV1\" = \"foo\" ]' > /tmp/example-script")
+					makeAccessibleOnlyByRoot("/tmp/example-script")
+
+					err := sshRemoteRunner.RunScriptWithEnv("/tmp/example-script", map[string]string{"ENV1": "foo"}, "")
+
+					Expect(err).NotTo(HaveOccurred())
+				})
+			})
 		})
-		Context("when the script is not there", func() {
+
+		When("the script is not there", func() {
 			It("returns a helpful error", func() {
 				err := sshRemoteRunner.RunScriptWithEnv("/tmp/example-script", map[string]string{}, "")
 

--- a/ssh/remote_runner_test.go
+++ b/ssh/remote_runner_test.go
@@ -377,6 +377,13 @@ var _ = Describe("SshRemoteRunner", func() {
 				Expect(err).NotTo(HaveOccurred())
 			})
 		})
+		Context("when the script is not there", func() {
+			It("returns a helpful error", func() {
+				err := sshRemoteRunner.RunScriptWithEnv("/tmp/example-script", map[string]string{}, "")
+
+				Expect(err).To(MatchError(ContainSubstring("command not found")))
+			})
+		})
 	})
 
 	Describe("FindFiles", func() {

--- a/testcluster/instance.go
+++ b/testcluster/instance.go
@@ -52,7 +52,12 @@ func NewInstanceWithKeepAlive(aliveInterval int) *Instance {
 }
 
 func (mockInstance *Instance) Address() string {
-	return strings.TrimSpace(strings.Replace(dockerRunAndWaitForSuccess("port", mockInstance.dockerID, "22"), "0.0.0.0", mockInstance.dockerHostIp(), -1))
+	localMapsForContainerPort22 := dockerRunAndWaitForSuccess("port", mockInstance.dockerID, "22")
+	localIPv4MapForContainerPort22Slice := strings.Split(localMapsForContainerPort22, "\n")
+	Expect(localIPv4MapForContainerPort22Slice).NotTo(BeNil())
+	Expect(len(localIPv4MapForContainerPort22Slice)).NotTo(BeZero())
+	localIPv4MapForContainerPort22 := localIPv4MapForContainerPort22Slice[0]
+	return strings.TrimSpace(strings.Replace(localIPv4MapForContainerPort22, "0.0.0.0", mockInstance.dockerHostIp(), -1))
 }
 
 func (mockInstance *Instance) IP() string {


### PR DESCRIPTION
We have heard reports that if a backup or restore script prints out huge amounts of data to stdout, this can cause the BBR CLI to crash.

The reason this happens seems to be that a method in the CLI was effectively buffering all the data from the script's stdout. This PR replaces that method (wherever possible) with one that does not buffer all that data, and so does not grow the memory footprint of the CLI in line with the stdout of the backup/restore scripts.

Along the way, we also make some of the tests more robust to recent versions of docker, ssh, etc.