### PR TITLE
Make BBR more robust to large stdout streams.

### DIFF
--- a/instance/deployed_instance_test.go
+++ b/instance/deployed_instance_test.go
@@ -514,13 +514,13 @@ var _ = Describe("DeployedInstance", func() {
 					),
 				})
 
-				remoteRunner.RunScriptWithEnvStub = func(cmd string, envVars map[string]string, label string, stdout io.Writer) (string, error) {
+				remoteRunner.RunScriptWithEnvStub = func(cmd string, envVars map[string]string, label string, stdout io.Writer) error {
 					if strings.Contains(cmd, "jobs/bar") {
-						return "", fmt.Errorf("no space left on device")
+						return fmt.Errorf("no space left on device")
 					} else if strings.Contains(cmd, "jobs/baz") {
-						return "", fmt.Errorf("huge failure")
+						return fmt.Errorf("huge failure")
 					} else {
-						return "not relevant", nil
+						return nil
 					}
 				}
 			})
@@ -762,13 +762,13 @@ var _ = Describe("DeployedInstance", func() {
 					),
 				})
 
-				remoteRunner.RunScriptWithEnvStub = func(cmd string, envVars map[string]string, label string, stdout io.Writer) (string, error) {
+				remoteRunner.RunScriptWithEnvStub = func(cmd string, envVars map[string]string, label string, stdout io.Writer) error {
 					if strings.Contains(cmd, "jobs/bar") {
-						return "", fmt.Errorf("no space left on device")
+						return fmt.Errorf("no space left on device")
 					} else if strings.Contains(cmd, "jobs/baz") {
-						return "", fmt.Errorf("huge failure")
+						return fmt.Errorf("huge failure")
 					} else {
-						return "not relevant", nil
+						return nil
 					}
 				}
 			})

--- a/instance/deployed_instance_test.go
+++ b/instance/deployed_instance_test.go
@@ -2,6 +2,7 @@ package instance_test
 
 import (
 	"fmt"
+	"io"
 	"log"
 	"strings"
 
@@ -323,21 +324,21 @@ var _ = Describe("DeployedInstance", func() {
 					"/var/vcap/store/bbr-backup/baz",
 				))
 
-				specifiedScriptPath, specifiedEnvVars, _ := remoteRunner.RunScriptWithEnvArgsForCall(0)
+				specifiedScriptPath, specifiedEnvVars, _, _ := remoteRunner.RunScriptWithEnvArgsForCall(0)
 				Expect(specifiedScriptPath).To(Equal("/var/vcap/jobs/foo/bin/bbr/backup"))
 				Expect(specifiedEnvVars).To(Equal(map[string]string{
 					"ARTIFACT_DIRECTORY":     "/var/vcap/store/bbr-backup/foo/",
 					"BBR_ARTIFACT_DIRECTORY": "/var/vcap/store/bbr-backup/foo/",
 				}))
 
-				specifiedScriptPath, specifiedEnvVars, _ = remoteRunner.RunScriptWithEnvArgsForCall(1)
+				specifiedScriptPath, specifiedEnvVars, _, _ = remoteRunner.RunScriptWithEnvArgsForCall(1)
 				Expect(specifiedScriptPath).To(Equal("/var/vcap/jobs/bar/bin/bbr/backup"))
 				Expect(specifiedEnvVars).To(Equal(map[string]string{
 					"ARTIFACT_DIRECTORY":     "/var/vcap/store/bbr-backup/bar/",
 					"BBR_ARTIFACT_DIRECTORY": "/var/vcap/store/bbr-backup/bar/",
 				}))
 
-				specifiedScriptPath, specifiedEnvVars, _ = remoteRunner.RunScriptWithEnvArgsForCall(2)
+				specifiedScriptPath, specifiedEnvVars, _, _ = remoteRunner.RunScriptWithEnvArgsForCall(2)
 				Expect(specifiedScriptPath).To(Equal("/var/vcap/jobs/baz/bin/bbr/backup"))
 				Expect(specifiedEnvVars).To(Equal(map[string]string{
 					"ARTIFACT_DIRECTORY":     "/var/vcap/store/bbr-backup/baz/",
@@ -421,14 +422,14 @@ var _ = Describe("DeployedInstance", func() {
 					"/var/vcap/store/bbr-backup/foo",
 					"/var/vcap/store/bbr-backup/baz-dave-backup-one-restore-all",
 				))
-				specifiedScriptPath, specifiedEnvVars, _ := remoteRunner.RunScriptWithEnvArgsForCall(0)
+				specifiedScriptPath, specifiedEnvVars, _, _ := remoteRunner.RunScriptWithEnvArgsForCall(0)
 				Expect(specifiedScriptPath).To(Equal("/var/vcap/jobs/foo/bin/bbr/backup"))
 				Expect(specifiedEnvVars).To(Equal(map[string]string{
 					"ARTIFACT_DIRECTORY":     "/var/vcap/store/bbr-backup/foo/",
 					"BBR_ARTIFACT_DIRECTORY": "/var/vcap/store/bbr-backup/foo/",
 				}))
 
-				specifiedScriptPath, specifiedEnvVars, _ = remoteRunner.RunScriptWithEnvArgsForCall(1)
+				specifiedScriptPath, specifiedEnvVars, _, _ = remoteRunner.RunScriptWithEnvArgsForCall(1)
 				Expect(specifiedScriptPath).To(Equal("/var/vcap/jobs/baz/bin/bbr/backup"))
 				Expect(specifiedEnvVars).To(Equal(map[string]string{
 					"ARTIFACT_DIRECTORY":     "/var/vcap/store/bbr-backup/baz-dave-backup-one-restore-all/",
@@ -513,7 +514,7 @@ var _ = Describe("DeployedInstance", func() {
 					),
 				})
 
-				remoteRunner.RunScriptWithEnvStub = func(cmd string, envVars map[string]string, label string) (string, error) {
+				remoteRunner.RunScriptWithEnvStub = func(cmd string, envVars map[string]string, label string, stdout io.Writer) (string, error) {
 					if strings.Contains(cmd, "jobs/bar") {
 						return "", fmt.Errorf("no space left on device")
 					} else if strings.Contains(cmd, "jobs/baz") {
@@ -595,21 +596,21 @@ var _ = Describe("DeployedInstance", func() {
 			It("uses the remote runner to run each restore script providing the correct ARTIFACT_DIRECTORY", func() {
 				Expect(remoteRunner.RunScriptWithEnvCallCount()).To(Equal(3))
 
-				specifiedScriptPath, specifiedEnvVars, _ := remoteRunner.RunScriptWithEnvArgsForCall(0)
+				specifiedScriptPath, specifiedEnvVars, _ , _:= remoteRunner.RunScriptWithEnvArgsForCall(0)
 				Expect(specifiedScriptPath).To(Equal("/var/vcap/jobs/foo/bin/bbr/restore"))
 				Expect(specifiedEnvVars).To(Equal(map[string]string{
 					"ARTIFACT_DIRECTORY":     "/var/vcap/store/bbr-backup/foo/",
 					"BBR_ARTIFACT_DIRECTORY": "/var/vcap/store/bbr-backup/foo/",
 				}))
 
-				specifiedScriptPath, specifiedEnvVars, _ = remoteRunner.RunScriptWithEnvArgsForCall(1)
+				specifiedScriptPath, specifiedEnvVars, _, _ = remoteRunner.RunScriptWithEnvArgsForCall(1)
 				Expect(specifiedScriptPath).To(Equal("/var/vcap/jobs/bar/bin/bbr/restore"))
 				Expect(specifiedEnvVars).To(Equal(map[string]string{
 					"ARTIFACT_DIRECTORY":     "/var/vcap/store/bbr-backup/bar/",
 					"BBR_ARTIFACT_DIRECTORY": "/var/vcap/store/bbr-backup/bar/",
 				}))
 
-				specifiedScriptPath, specifiedEnvVars, _ = remoteRunner.RunScriptWithEnvArgsForCall(2)
+				specifiedScriptPath, specifiedEnvVars, _, _= remoteRunner.RunScriptWithEnvArgsForCall(2)
 				Expect(specifiedScriptPath).To(Equal("/var/vcap/jobs/baz/bin/bbr/restore"))
 				Expect(specifiedEnvVars).To(Equal(map[string]string{
 					"ARTIFACT_DIRECTORY":     "/var/vcap/store/bbr-backup/baz/",
@@ -697,21 +698,21 @@ var _ = Describe("DeployedInstance", func() {
 			It("uses the remote runner to create each job's backup folder and run each backup script providing the correct BBR_ARTIFACT_DIRECTORY and ARTIFACT_DIRECTORY", func() {
 				Expect(remoteRunner.RunScriptWithEnvCallCount()).To(Equal(3))
 
-				specifiedScriptPath, specifiedEnvVars, _ := remoteRunner.RunScriptWithEnvArgsForCall(0)
+				specifiedScriptPath, specifiedEnvVars, _ , _ := remoteRunner.RunScriptWithEnvArgsForCall(0)
 				Expect(specifiedScriptPath).To(Equal("/var/vcap/jobs/foo/bin/bbr/restore"))
 				Expect(specifiedEnvVars).To(Equal(map[string]string{
 					"ARTIFACT_DIRECTORY":     "/var/vcap/store/bbr-backup/foo/",
 					"BBR_ARTIFACT_DIRECTORY": "/var/vcap/store/bbr-backup/foo/",
 				}))
 
-				specifiedScriptPath, specifiedEnvVars, _ = remoteRunner.RunScriptWithEnvArgsForCall(1)
+				specifiedScriptPath, specifiedEnvVars, _, _ = remoteRunner.RunScriptWithEnvArgsForCall(1)
 				Expect(specifiedScriptPath).To(Equal("/var/vcap/jobs/bar/bin/bbr/restore"))
 				Expect(specifiedEnvVars).To(Equal(map[string]string{
 					"ARTIFACT_DIRECTORY":     "/var/vcap/store/bbr-backup/bar/",
 					"BBR_ARTIFACT_DIRECTORY": "/var/vcap/store/bbr-backup/bar/",
 				}))
 
-				specifiedScriptPath, specifiedEnvVars, _ = remoteRunner.RunScriptWithEnvArgsForCall(2)
+				specifiedScriptPath, specifiedEnvVars, _ , _ = remoteRunner.RunScriptWithEnvArgsForCall(2)
 				Expect(specifiedScriptPath).To(Equal("/var/vcap/jobs/baz/bin/bbr/restore"))
 				Expect(specifiedEnvVars).To(Equal(map[string]string{
 					"ARTIFACT_DIRECTORY":     "/var/vcap/store/bbr-backup/special-backup/",
@@ -761,7 +762,7 @@ var _ = Describe("DeployedInstance", func() {
 					),
 				})
 
-				remoteRunner.RunScriptWithEnvStub = func(cmd string, envVars map[string]string, label string) (string, error) {
+				remoteRunner.RunScriptWithEnvStub = func(cmd string, envVars map[string]string, label string, stdout io.Writer) (string, error) {
 					if strings.Contains(cmd, "jobs/bar") {
 						return "", fmt.Errorf("no space left on device")
 					} else if strings.Contains(cmd, "jobs/baz") {

--- a/instance/job.go
+++ b/instance/job.go
@@ -125,7 +125,7 @@ func (j Job) Backup() error {
 		}
 
 		env := artifactDirectoryVariables(j.BackupArtifactDirectory())
-		_, err = j.remoteRunner.RunScriptWithEnv(
+		err = j.remoteRunner.RunScriptWithEnv(
 			string(j.backupScript),
 			env,
 			fmt.Sprintf("backup %s on %s", j.name, j.instanceIdentifier),
@@ -153,7 +153,7 @@ func (j Job) PreBackupLock() error {
 		j.Logger.Debug("bbr", "> %s", j.preBackupScript)
 		j.Logger.Info("bbr", "Locking %s on %s for backup...", j.name, j.instanceIdentifier)
 
-		_, err := j.remoteRunner.RunScript(
+		err := j.remoteRunner.RunScript(
 			string(j.preBackupScript),
 			fmt.Sprintf("pre-backup lock %s on %s", j.name, j.instanceIdentifier),
 		)
@@ -180,7 +180,7 @@ func (j Job) PostBackupUnlock(afterSuccessfulBackup bool) error {
 		env := map[string]string{
 			"BBR_AFTER_BACKUP_SCRIPTS_SUCCESSFUL": strconv.FormatBool(afterSuccessfulBackup),
 		}
-		_, err := j.remoteRunner.RunScriptWithEnv(
+		err := j.remoteRunner.RunScriptWithEnv(
 			string(j.postBackupScript),
 			env,
 			fmt.Sprintf("post-backup unlock %s on %s", j.name, j.instanceIdentifier),
@@ -207,7 +207,7 @@ func (j Job) PreRestoreLock() error {
 		j.Logger.Debug("bbr", "> %s", j.preRestoreScript)
 		j.Logger.Info("bbr", "Locking %s on %s for restore...", j.name, j.instanceIdentifier)
 
-		_, err := j.remoteRunner.RunScript(
+		err := j.remoteRunner.RunScript(
 			string(j.preRestoreScript),
 			fmt.Sprintf("pre-restore lock %s on %s", j.name, j.instanceIdentifier),
 		)
@@ -233,7 +233,7 @@ func (j Job) Restore() error {
 		j.Logger.Info("bbr", "Restoring %s on %s...", j.name, j.instanceIdentifier)
 
 		env := artifactDirectoryVariables(j.RestoreArtifactDirectory())
-		_, err := j.remoteRunner.RunScriptWithEnv(
+		err := j.remoteRunner.RunScriptWithEnv(
 			string(j.restoreScript), env,
 			fmt.Sprintf("restore %s on %s", j.name, j.instanceIdentifier),
 			io.Discard,
@@ -259,7 +259,7 @@ func (j Job) PostRestoreUnlock() error {
 		j.Logger.Debug("bbr", "> %s", j.postRestoreScript)
 		j.Logger.Info("bbr", "Unlocking %s on %s...", j.name, j.instanceIdentifier)
 
-		_, err := j.remoteRunner.RunScript(
+		err := j.remoteRunner.RunScript(
 			string(j.postRestoreScript),
 			fmt.Sprintf("post-restore unlock %s on %s", j.name, j.instanceIdentifier),
 		)

--- a/instance/job.go
+++ b/instance/job.go
@@ -2,6 +2,7 @@ package instance
 
 import (
 	"fmt"
+	"io"
 	"strconv"
 
 	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/orchestrator"
@@ -128,6 +129,7 @@ func (j Job) Backup() error {
 			string(j.backupScript),
 			env,
 			fmt.Sprintf("backup %s on %s", j.name, j.instanceIdentifier),
+			io.Discard,
 		)
 
 		if err != nil {
@@ -182,6 +184,7 @@ func (j Job) PostBackupUnlock(afterSuccessfulBackup bool) error {
 			string(j.postBackupScript),
 			env,
 			fmt.Sprintf("post-backup unlock %s on %s", j.name, j.instanceIdentifier),
+			io.Discard,
 		)
 		if err != nil {
 			j.Logger.Error("bbr", "Error unlocking %s on %s.", j.name, j.instanceIdentifier)
@@ -233,6 +236,7 @@ func (j Job) Restore() error {
 		_, err := j.remoteRunner.RunScriptWithEnv(
 			string(j.restoreScript), env,
 			fmt.Sprintf("restore %s on %s", j.name, j.instanceIdentifier),
+			io.Discard,
 		)
 		if err != nil {
 			j.Logger.Error("bbr", "Error restoring %s on %s.", j.name, j.instanceIdentifier)

--- a/instance/job_finder.go
+++ b/instance/job_finder.go
@@ -1,8 +1,8 @@
 package instance
 
 import (
+	"bytes"
 	"fmt"
-	"io"
 	"path/filepath"
 
 	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/orchestrator"
@@ -102,11 +102,12 @@ func (j *JobFinderFromScripts) findBBRScripts(instanceIdentifierForLogging Insta
 }
 
 func (j *JobFinderFromScripts) findMetadata(instanceIdentifier InstanceIdentifier, script Script, remoteRunner ssh.RemoteRunner) (*Metadata, error) {
-	metadataContent, err := remoteRunner.RunScriptWithEnv(
+	metadataBuffer := &bytes.Buffer{}
+	_, err := remoteRunner.RunScriptWithEnv(
 		string(script),
 		map[string]string{"BBR_VERSION": j.bbrVersion},
 		fmt.Sprintf("find metadata for %s on %s", script.JobName(), instanceIdentifier),
-		io.Discard,
+		metadataBuffer,
 	)
 	if err != nil {
 		return nil, errors.Wrapf(
@@ -116,7 +117,7 @@ func (j *JobFinderFromScripts) findMetadata(instanceIdentifier InstanceIdentifie
 			instanceIdentifier,
 		)
 	}
-	jobMetadata, err := j.parseJobMetadata(metadataContent)
+	jobMetadata, err := j.parseJobMetadata(string(metadataBuffer.Bytes()))
 	if err != nil {
 		return nil, errors.Wrapf(
 			err,

--- a/instance/job_finder.go
+++ b/instance/job_finder.go
@@ -2,6 +2,7 @@ package instance
 
 import (
 	"fmt"
+	"io"
 	"path/filepath"
 
 	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/orchestrator"
@@ -105,6 +106,7 @@ func (j *JobFinderFromScripts) findMetadata(instanceIdentifier InstanceIdentifie
 		string(script),
 		map[string]string{"BBR_VERSION": j.bbrVersion},
 		fmt.Sprintf("find metadata for %s on %s", script.JobName(), instanceIdentifier),
+		io.Discard,
 	)
 	if err != nil {
 		return nil, errors.Wrapf(

--- a/instance/job_finder.go
+++ b/instance/job_finder.go
@@ -103,7 +103,7 @@ func (j *JobFinderFromScripts) findBBRScripts(instanceIdentifierForLogging Insta
 
 func (j *JobFinderFromScripts) findMetadata(instanceIdentifier InstanceIdentifier, script Script, remoteRunner ssh.RemoteRunner) (*Metadata, error) {
 	metadataBuffer := &bytes.Buffer{}
-	_, err := remoteRunner.RunScriptWithEnv(
+	err := remoteRunner.RunScriptWithEnv(
 		string(script),
 		map[string]string{"BBR_VERSION": j.bbrVersion},
 		fmt.Sprintf("find metadata for %s on %s", script.JobName(), instanceIdentifier),

--- a/instance/job_finder_test.go
+++ b/instance/job_finder_test.go
@@ -262,7 +262,7 @@ backup_should_be_locked_before:
 
 				It("attaches the metadata to the corresponding jobs", func() {
 					By("executing the metadata scripts passing the correct arguments", func() {
-						cmd, env, _ := remoteRunner.RunScriptWithEnvArgsForCall(0)
+						cmd, env, _, _ := remoteRunner.RunScriptWithEnvArgsForCall(0)
 						Expect(cmd).To(Equal("/var/vcap/jobs/consul_agent/bin/bbr/metadata"))
 						Expect(env).To(Equal(map[string]string{"BBR_VERSION": bbrVersion}))
 					})
@@ -300,7 +300,7 @@ backup_should_be_locked_before:
 
 					It("attaches the metadata to the corresponding jobs", func() {
 						By("executing the metadata scripts passing the correct arguments", func() {
-							cmd, env, _ := remoteRunner.RunScriptWithEnvArgsForCall(0)
+							cmd, env, _ , _ := remoteRunner.RunScriptWithEnvArgsForCall(0)
 							Expect(cmd).To(Equal("/var/vcap/jobs/consul_agent/bin/bbr/metadata"))
 							Expect(env).To(Equal(map[string]string{"BBR_VERSION": bbrVersion}))
 						})
@@ -390,7 +390,7 @@ skip_bbr_scripts: true
 
 				It("ignores the job", func() {
 					By("executing the metadata scripts passing the correct arguments", func() {
-						cmd, env, _ := remoteRunner.RunScriptWithEnvArgsForCall(0)
+						cmd, env, _, _ := remoteRunner.RunScriptWithEnvArgsForCall(0)
 						Expect(cmd).To(Equal("/var/vcap/jobs/consul_agent/bin/bbr/metadata"))
 						Expect(env).To(Equal(map[string]string{"BBR_VERSION": bbrVersion}))
 					})

--- a/instance/job_finder_test.go
+++ b/instance/job_finder_test.go
@@ -252,12 +252,14 @@ var _ = Describe("JobFinderFromScripts", func() {
 			Context("when metadata is valid", func() {
 				BeforeEach(func() {
 					remoteRunner.FindFilesReturns([]string{"/var/vcap/jobs/consul_agent/bin/bbr/metadata"}, nil)
-					remoteRunner.RunScriptWithEnvReturns(`---
+					remoteRunner.RunScriptWithEnvStub = func(_ string, _ map[string]string, _ string, stdout io.Writer) (string, error) {
+						stdout.Write([]byte(`---
 backup_name: consul_backup
 restore_name: consul_backup
 backup_should_be_locked_before:
 - job_name: bosh
-  release: bosh`, nil)
+  release: bosh`))
+						return "", nil}
 				})
 
 				It("attaches the metadata to the corresponding jobs", func() {
@@ -370,7 +372,9 @@ backup_should_be_locked_before:
 			Context("when a metadata script returns invalid metadata YAML", func() {
 				BeforeEach(func() {
 					remoteRunner.FindFilesReturns([]string{"/var/vcap/jobs/consul_agent/bin/bbr/metadata"}, nil)
-					remoteRunner.RunScriptWithEnvReturns(`this metadata is missing all the keys`, nil)
+					remoteRunner.RunScriptWithEnvStub = func(_ string, _ map[string]string, _ string, stdout io.Writer) (string, error) {
+						stdout.Write([]byte(`this metadata is missing all the keys`))
+						return "", nil}
 				})
 
 				It("prints the location of the error", func() {
@@ -383,9 +387,10 @@ backup_should_be_locked_before:
 			Context("when the bbr job is disabled", func() {
 				BeforeEach(func() {
 					remoteRunner.FindFilesReturns([]string{"/var/vcap/jobs/consul_agent/bin/bbr/metadata"}, nil)
-					remoteRunner.RunScriptWithEnvReturns(`---
-skip_bbr_scripts: true
-`, nil)
+					remoteRunner.RunScriptWithEnvStub = func(_ string, _ map[string]string, _ string, stdout io.Writer) (string, error) {
+						stdout.Write([]byte(`---
+skip_bbr_scripts: true`))
+						return "", nil}
 				})
 
 				It("ignores the job", func() {

--- a/instance/job_finder_test.go
+++ b/instance/job_finder_test.go
@@ -252,14 +252,14 @@ var _ = Describe("JobFinderFromScripts", func() {
 			Context("when metadata is valid", func() {
 				BeforeEach(func() {
 					remoteRunner.FindFilesReturns([]string{"/var/vcap/jobs/consul_agent/bin/bbr/metadata"}, nil)
-					remoteRunner.RunScriptWithEnvStub = func(_ string, _ map[string]string, _ string, stdout io.Writer) (string, error) {
+					remoteRunner.RunScriptWithEnvStub = func(_ string, _ map[string]string, _ string, stdout io.Writer) error {
 						stdout.Write([]byte(`---
 backup_name: consul_backup
 restore_name: consul_backup
 backup_should_be_locked_before:
 - job_name: bosh
   release: bosh`))
-						return "", nil}
+						return nil}
 				})
 
 				It("attaches the metadata to the corresponding jobs", func() {
@@ -357,7 +357,7 @@ backup_should_be_locked_before:
 			Context("when executing a metadata script fails", func() {
 				BeforeEach(func() {
 					remoteRunner.FindFilesReturns([]string{"/var/vcap/jobs/consul_agent/bin/bbr/metadata"}, nil)
-					remoteRunner.RunScriptWithEnvReturns("", fmt.Errorf("blah blah blah foo"))
+					remoteRunner.RunScriptWithEnvReturns(fmt.Errorf("blah blah blah foo"))
 				})
 
 				It("printing the location of the error, and the original error message", func() {
@@ -372,9 +372,9 @@ backup_should_be_locked_before:
 			Context("when a metadata script returns invalid metadata YAML", func() {
 				BeforeEach(func() {
 					remoteRunner.FindFilesReturns([]string{"/var/vcap/jobs/consul_agent/bin/bbr/metadata"}, nil)
-					remoteRunner.RunScriptWithEnvStub = func(_ string, _ map[string]string, _ string, stdout io.Writer) (string, error) {
+					remoteRunner.RunScriptWithEnvStub = func(_ string, _ map[string]string, _ string, stdout io.Writer) error {
 						stdout.Write([]byte(`this metadata is missing all the keys`))
-						return "", nil}
+						return nil}
 				})
 
 				It("prints the location of the error", func() {
@@ -387,10 +387,10 @@ backup_should_be_locked_before:
 			Context("when the bbr job is disabled", func() {
 				BeforeEach(func() {
 					remoteRunner.FindFilesReturns([]string{"/var/vcap/jobs/consul_agent/bin/bbr/metadata"}, nil)
-					remoteRunner.RunScriptWithEnvStub = func(_ string, _ map[string]string, _ string, stdout io.Writer) (string, error) {
+					remoteRunner.RunScriptWithEnvStub = func(_ string, _ map[string]string, _ string, stdout io.Writer) error {
 						stdout.Write([]byte(`---
 skip_bbr_scripts: true`))
-						return "", nil}
+						return nil}
 				})
 
 				It("ignores the job", func() {

--- a/instance/job_test.go
+++ b/instance/job_test.go
@@ -372,7 +372,7 @@ var _ = Describe("Job", func() {
 				Expect(remoteRunner.RunScriptWithEnvCallCount()).To(Equal(1))
 
 				Expect(remoteRunner.CreateDirectoryArgsForCall(0)).To(Equal("/var/vcap/store/bbr-backup/jobname"))
-				specifiedScriptPath, specifiedEnvVars, _ := remoteRunner.RunScriptWithEnvArgsForCall(0)
+				specifiedScriptPath, specifiedEnvVars, _, _ := remoteRunner.RunScriptWithEnvArgsForCall(0)
 				Expect(specifiedScriptPath).To(Equal("/var/vcap/jobs/jobname/bin/bbr/backup"))
 				Expect(specifiedEnvVars).To(SatisfyAll(
 					HaveLen(2),
@@ -432,7 +432,7 @@ var _ = Describe("Job", func() {
 			It("uses the remote runner to run the script", func() {
 				Expect(remoteRunner.RunScriptWithEnvCallCount()).To(Equal(1))
 
-				specifiedScriptPath, specifiedEnvVars, _ := remoteRunner.RunScriptWithEnvArgsForCall(0)
+				specifiedScriptPath, specifiedEnvVars, _, _ := remoteRunner.RunScriptWithEnvArgsForCall(0)
 				Expect(specifiedScriptPath).To(Equal("/var/vcap/jobs/jobname/bin/bbr/restore"))
 				Expect(specifiedEnvVars).To(SatisfyAll(
 					HaveLen(2),
@@ -573,7 +573,7 @@ var _ = Describe("Job", func() {
 
 				It("uses remote runner to run the script", func() {
 					Expect(remoteRunner.RunScriptWithEnvCallCount()).To(Equal(1))
-					cmd, envVars, _ := remoteRunner.RunScriptWithEnvArgsForCall(0)
+					cmd, envVars, _, _ := remoteRunner.RunScriptWithEnvArgsForCall(0)
 					Expect(cmd).To(Equal("/var/vcap/jobs/jobname/bin/bbr/post-backup-unlock"))
 					Expect(envVars).To(HaveKeyWithValue("BBR_AFTER_BACKUP_SCRIPTS_SUCCESSFUL", "true"))
 				})
@@ -599,7 +599,7 @@ var _ = Describe("Job", func() {
 
 				It("uses remote runner to run the script", func() {
 					Expect(remoteRunner.RunScriptWithEnvCallCount()).To(Equal(1))
-					cmd, envVars, _ := remoteRunner.RunScriptWithEnvArgsForCall(0)
+					cmd, envVars, _, _ := remoteRunner.RunScriptWithEnvArgsForCall(0)
 					Expect(cmd).To(Equal("/var/vcap/jobs/jobname/bin/bbr/post-backup-unlock"))
 					Expect(envVars).To(HaveKeyWithValue("BBR_AFTER_BACKUP_SCRIPTS_SUCCESSFUL", "false"))
 				})

--- a/instance/job_test.go
+++ b/instance/job_test.go
@@ -383,7 +383,7 @@ var _ = Describe("Job", func() {
 
 			Context("backup script runs successfully", func() {
 				BeforeEach(func() {
-					remoteRunner.RunScriptWithEnvReturns("stdout", nil)
+					remoteRunner.RunScriptWithEnvReturns(nil)
 				})
 
 				It("succeeds", func() {
@@ -393,7 +393,7 @@ var _ = Describe("Job", func() {
 
 			Context("backup script fails", func() {
 				BeforeEach(func() {
-					remoteRunner.RunScriptWithEnvReturns("", fmt.Errorf("some weird error"))
+					remoteRunner.RunScriptWithEnvReturns(fmt.Errorf("some weird error"))
 				})
 
 				It("fails", func() {
@@ -443,7 +443,7 @@ var _ = Describe("Job", func() {
 
 			Context("restore script runs successfully", func() {
 				BeforeEach(func() {
-					remoteRunner.RunScriptWithEnvReturns("", nil)
+					remoteRunner.RunScriptWithEnvReturns(nil)
 				})
 
 				It("succeeds", func() {
@@ -453,7 +453,7 @@ var _ = Describe("Job", func() {
 
 			Context("restore script fails", func() {
 				BeforeEach(func() {
-					remoteRunner.RunScriptWithEnvReturns("", fmt.Errorf("it went wrong"))
+					remoteRunner.RunScriptWithEnvReturns(fmt.Errorf("it went wrong"))
 				})
 
 				It("fails", func() {
@@ -515,7 +515,7 @@ var _ = Describe("Job", func() {
 
 			Context("pre-backup-lock script runs successfully", func() {
 				BeforeEach(func() {
-					remoteRunner.RunScriptReturns("stdout", nil)
+					remoteRunner.RunScriptReturns(nil)
 				})
 
 				It("succeeds", func() {
@@ -525,7 +525,7 @@ var _ = Describe("Job", func() {
 
 			Context("pre-backup-lock script errors", func() {
 				BeforeEach(func() {
-					remoteRunner.RunScriptReturns("", fmt.Errorf("some strange error"))
+					remoteRunner.RunScriptReturns(fmt.Errorf("some strange error"))
 				})
 
 				It("fails", func() {
@@ -580,7 +580,7 @@ var _ = Describe("Job", func() {
 
 				Context("post-backup-unlock script runs successfully", func() {
 					BeforeEach(func() {
-						remoteRunner.RunScriptWithEnvReturns("stdout", nil)
+						remoteRunner.RunScriptWithEnvReturns(nil)
 					})
 
 					It("succeeds", func() {
@@ -608,7 +608,7 @@ var _ = Describe("Job", func() {
 
 			Context("post-backup-unlock script fails", func() {
 				BeforeEach(func() {
-					remoteRunner.RunScriptWithEnvReturns("", fmt.Errorf("it failed"))
+					remoteRunner.RunScriptWithEnvReturns(fmt.Errorf("it failed"))
 				})
 
 				It("fails", func() {
@@ -675,7 +675,7 @@ var _ = Describe("Job", func() {
 
 			Context("pre-restore-lock script runs successfully", func() {
 				BeforeEach(func() {
-					remoteRunner.RunScriptReturns("stdout", nil)
+					remoteRunner.RunScriptReturns(nil)
 				})
 
 				It("succeeds", func() {
@@ -685,7 +685,7 @@ var _ = Describe("Job", func() {
 
 			Context("pre-restore-lock script fails", func() {
 				BeforeEach(func() {
-					remoteRunner.RunScriptReturns("", fmt.Errorf("some strange error"))
+					remoteRunner.RunScriptReturns(fmt.Errorf("some strange error"))
 				})
 
 				It("fails", func() {
@@ -731,7 +731,7 @@ var _ = Describe("Job", func() {
 
 			Context("post-restore-unlock script runs successfully", func() {
 				BeforeEach(func() {
-					remoteRunner.RunScriptReturns("stdout", nil)
+					remoteRunner.RunScriptReturns(nil)
 				})
 
 				It("succeeds", func() {
@@ -741,7 +741,7 @@ var _ = Describe("Job", func() {
 
 			Context("post-restore-unlock script fails", func() {
 				BeforeEach(func() {
-					remoteRunner.RunScriptReturns("", fmt.Errorf("oh no"))
+					remoteRunner.RunScriptReturns(fmt.Errorf("oh no"))
 				})
 
 				It("fails", func() {

--- a/ssh/fakes/fake_logger.go
+++ b/ssh/fakes/fake_logger.go
@@ -40,9 +40,10 @@ func (fake *FakeLogger) Debug(arg1 string, arg2 string, arg3 ...interface{}) {
 		arg2 string
 		arg3 []interface{}
 	}{arg1, arg2, arg3})
+	stub := fake.DebugStub
 	fake.recordInvocation("Debug", []interface{}{arg1, arg2, arg3})
 	fake.debugMutex.Unlock()
-	if fake.DebugStub != nil {
+	if stub != nil {
 		fake.DebugStub(arg1, arg2, arg3...)
 	}
 }
@@ -73,9 +74,10 @@ func (fake *FakeLogger) Error(arg1 string, arg2 string, arg3 ...interface{}) {
 		arg2 string
 		arg3 []interface{}
 	}{arg1, arg2, arg3})
+	stub := fake.ErrorStub
 	fake.recordInvocation("Error", []interface{}{arg1, arg2, arg3})
 	fake.errorMutex.Unlock()
-	if fake.ErrorStub != nil {
+	if stub != nil {
 		fake.ErrorStub(arg1, arg2, arg3...)
 	}
 }
@@ -106,9 +108,10 @@ func (fake *FakeLogger) Warn(arg1 string, arg2 string, arg3 ...interface{}) {
 		arg2 string
 		arg3 []interface{}
 	}{arg1, arg2, arg3})
+	stub := fake.WarnStub
 	fake.recordInvocation("Warn", []interface{}{arg1, arg2, arg3})
 	fake.warnMutex.Unlock()
-	if fake.WarnStub != nil {
+	if stub != nil {
 		fake.WarnStub(arg1, arg2, arg3...)
 	}
 }

--- a/ssh/fakes/fake_opts_generator.go
+++ b/ssh/fakes/fake_opts_generator.go
@@ -35,15 +35,17 @@ func (fake *FakeSSHOptsGenerator) Spy(arg1 uuid.Generator) (director.SSHOpts, st
 	fake.argsForCall = append(fake.argsForCall, struct {
 		arg1 uuid.Generator
 	}{arg1})
+	stub := fake.Stub
+	returns := fake.returns
 	fake.recordInvocation("SSHOptsGenerator", []interface{}{arg1})
 	fake.mutex.Unlock()
-	if fake.Stub != nil {
-		return fake.Stub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	return fake.returns.result1, fake.returns.result2, fake.returns.result3
+	return returns.result1, returns.result2, returns.result3
 }
 
 func (fake *FakeSSHOptsGenerator) CallCount() int {

--- a/ssh/fakes/fake_remote_runner.go
+++ b/ssh/fakes/fake_remote_runner.go
@@ -116,21 +116,19 @@ type FakeRemoteRunner struct {
 	removeDirectoryReturnsOnCall map[int]struct {
 		result1 error
 	}
-	RunScriptStub        func(string, string) (string, error)
+	RunScriptStub        func(string, string) error
 	runScriptMutex       sync.RWMutex
 	runScriptArgsForCall []struct {
 		arg1 string
 		arg2 string
 	}
 	runScriptReturns struct {
-		result1 string
-		result2 error
+		result1 error
 	}
 	runScriptReturnsOnCall map[int]struct {
-		result1 string
-		result2 error
+		result1 error
 	}
-	RunScriptWithEnvStub        func(string, map[string]string, string, io.Writer) (string, error)
+	RunScriptWithEnvStub        func(string, map[string]string, string, io.Writer) error
 	runScriptWithEnvMutex       sync.RWMutex
 	runScriptWithEnvArgsForCall []struct {
 		arg1 string
@@ -139,12 +137,10 @@ type FakeRemoteRunner struct {
 		arg4 io.Writer
 	}
 	runScriptWithEnvReturns struct {
-		result1 string
-		result2 error
+		result1 error
 	}
 	runScriptWithEnvReturnsOnCall map[int]struct {
-		result1 string
-		result2 error
+		result1 error
 	}
 	SizeInBytesStub        func(string) (int, error)
 	sizeInBytesMutex       sync.RWMutex
@@ -723,7 +719,7 @@ func (fake *FakeRemoteRunner) RemoveDirectoryReturnsOnCall(i int, result1 error)
 	}{result1}
 }
 
-func (fake *FakeRemoteRunner) RunScript(arg1 string, arg2 string) (string, error) {
+func (fake *FakeRemoteRunner) RunScript(arg1 string, arg2 string) error {
 	fake.runScriptMutex.Lock()
 	ret, specificReturn := fake.runScriptReturnsOnCall[len(fake.runScriptArgsForCall)]
 	fake.runScriptArgsForCall = append(fake.runScriptArgsForCall, struct {
@@ -738,9 +734,9 @@ func (fake *FakeRemoteRunner) RunScript(arg1 string, arg2 string) (string, error
 		return stub(arg1, arg2)
 	}
 	if specificReturn {
-		return ret.result1, ret.result2
+		return ret.result1
 	}
-	return fakeReturns.result1, fakeReturns.result2
+	return fakeReturns.result1
 }
 
 func (fake *FakeRemoteRunner) RunScriptCallCount() int {
@@ -749,7 +745,7 @@ func (fake *FakeRemoteRunner) RunScriptCallCount() int {
 	return len(fake.runScriptArgsForCall)
 }
 
-func (fake *FakeRemoteRunner) RunScriptCalls(stub func(string, string) (string, error)) {
+func (fake *FakeRemoteRunner) RunScriptCalls(stub func(string, string) error) {
 	fake.runScriptMutex.Lock()
 	defer fake.runScriptMutex.Unlock()
 	fake.RunScriptStub = stub
@@ -762,33 +758,30 @@ func (fake *FakeRemoteRunner) RunScriptArgsForCall(i int) (string, string) {
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *FakeRemoteRunner) RunScriptReturns(result1 string, result2 error) {
+func (fake *FakeRemoteRunner) RunScriptReturns(result1 error) {
 	fake.runScriptMutex.Lock()
 	defer fake.runScriptMutex.Unlock()
 	fake.RunScriptStub = nil
 	fake.runScriptReturns = struct {
-		result1 string
-		result2 error
-	}{result1, result2}
+		result1 error
+	}{result1}
 }
 
-func (fake *FakeRemoteRunner) RunScriptReturnsOnCall(i int, result1 string, result2 error) {
+func (fake *FakeRemoteRunner) RunScriptReturnsOnCall(i int, result1 error) {
 	fake.runScriptMutex.Lock()
 	defer fake.runScriptMutex.Unlock()
 	fake.RunScriptStub = nil
 	if fake.runScriptReturnsOnCall == nil {
 		fake.runScriptReturnsOnCall = make(map[int]struct {
-			result1 string
-			result2 error
+			result1 error
 		})
 	}
 	fake.runScriptReturnsOnCall[i] = struct {
-		result1 string
-		result2 error
-	}{result1, result2}
+		result1 error
+	}{result1}
 }
 
-func (fake *FakeRemoteRunner) RunScriptWithEnv(arg1 string, arg2 map[string]string, arg3 string, arg4 io.Writer) (string, error) {
+func (fake *FakeRemoteRunner) RunScriptWithEnv(arg1 string, arg2 map[string]string, arg3 string, arg4 io.Writer) error {
 	fake.runScriptWithEnvMutex.Lock()
 	ret, specificReturn := fake.runScriptWithEnvReturnsOnCall[len(fake.runScriptWithEnvArgsForCall)]
 	fake.runScriptWithEnvArgsForCall = append(fake.runScriptWithEnvArgsForCall, struct {
@@ -805,9 +798,9 @@ func (fake *FakeRemoteRunner) RunScriptWithEnv(arg1 string, arg2 map[string]stri
 		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
-		return ret.result1, ret.result2
+		return ret.result1
 	}
-	return fakeReturns.result1, fakeReturns.result2
+	return fakeReturns.result1
 }
 
 func (fake *FakeRemoteRunner) RunScriptWithEnvCallCount() int {
@@ -816,7 +809,7 @@ func (fake *FakeRemoteRunner) RunScriptWithEnvCallCount() int {
 	return len(fake.runScriptWithEnvArgsForCall)
 }
 
-func (fake *FakeRemoteRunner) RunScriptWithEnvCalls(stub func(string, map[string]string, string, io.Writer) (string, error)) {
+func (fake *FakeRemoteRunner) RunScriptWithEnvCalls(stub func(string, map[string]string, string, io.Writer) error) {
 	fake.runScriptWithEnvMutex.Lock()
 	defer fake.runScriptWithEnvMutex.Unlock()
 	fake.RunScriptWithEnvStub = stub
@@ -829,30 +822,27 @@ func (fake *FakeRemoteRunner) RunScriptWithEnvArgsForCall(i int) (string, map[st
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
-func (fake *FakeRemoteRunner) RunScriptWithEnvReturns(result1 string, result2 error) {
+func (fake *FakeRemoteRunner) RunScriptWithEnvReturns(result1 error) {
 	fake.runScriptWithEnvMutex.Lock()
 	defer fake.runScriptWithEnvMutex.Unlock()
 	fake.RunScriptWithEnvStub = nil
 	fake.runScriptWithEnvReturns = struct {
-		result1 string
-		result2 error
-	}{result1, result2}
+		result1 error
+	}{result1}
 }
 
-func (fake *FakeRemoteRunner) RunScriptWithEnvReturnsOnCall(i int, result1 string, result2 error) {
+func (fake *FakeRemoteRunner) RunScriptWithEnvReturnsOnCall(i int, result1 error) {
 	fake.runScriptWithEnvMutex.Lock()
 	defer fake.runScriptWithEnvMutex.Unlock()
 	fake.RunScriptWithEnvStub = nil
 	if fake.runScriptWithEnvReturnsOnCall == nil {
 		fake.runScriptWithEnvReturnsOnCall = make(map[int]struct {
-			result1 string
-			result2 error
+			result1 error
 		})
 	}
 	fake.runScriptWithEnvReturnsOnCall[i] = struct {
-		result1 string
-		result2 error
-	}{result1, result2}
+		result1 error
+	}{result1}
 }
 
 func (fake *FakeRemoteRunner) SizeInBytes(arg1 string) (int, error) {

--- a/ssh/fakes/fake_remote_runner.go
+++ b/ssh/fakes/fake_remote_runner.go
@@ -130,12 +130,13 @@ type FakeRemoteRunner struct {
 		result1 string
 		result2 error
 	}
-	RunScriptWithEnvStub        func(string, map[string]string, string) (string, error)
+	RunScriptWithEnvStub        func(string, map[string]string, string, io.Writer) (string, error)
 	runScriptWithEnvMutex       sync.RWMutex
 	runScriptWithEnvArgsForCall []struct {
 		arg1 string
 		arg2 map[string]string
 		arg3 string
+		arg4 io.Writer
 	}
 	runScriptWithEnvReturns struct {
 		result1 string
@@ -182,15 +183,16 @@ func (fake *FakeRemoteRunner) ArchiveAndDownload(arg1 string, arg2 io.Writer) er
 		arg1 string
 		arg2 io.Writer
 	}{arg1, arg2})
+	stub := fake.ArchiveAndDownloadStub
+	fakeReturns := fake.archiveAndDownloadReturns
 	fake.recordInvocation("ArchiveAndDownload", []interface{}{arg1, arg2})
 	fake.archiveAndDownloadMutex.Unlock()
-	if fake.ArchiveAndDownloadStub != nil {
-		return fake.ArchiveAndDownloadStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.archiveAndDownloadReturns
 	return fakeReturns.result1
 }
 
@@ -242,15 +244,16 @@ func (fake *FakeRemoteRunner) ChecksumDirectory(arg1 string) (map[string]string,
 	fake.checksumDirectoryArgsForCall = append(fake.checksumDirectoryArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.ChecksumDirectoryStub
+	fakeReturns := fake.checksumDirectoryReturns
 	fake.recordInvocation("ChecksumDirectory", []interface{}{arg1})
 	fake.checksumDirectoryMutex.Unlock()
-	if fake.ChecksumDirectoryStub != nil {
-		return fake.ChecksumDirectoryStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.checksumDirectoryReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -304,15 +307,16 @@ func (fake *FakeRemoteRunner) ConnectedUsername() string {
 	ret, specificReturn := fake.connectedUsernameReturnsOnCall[len(fake.connectedUsernameArgsForCall)]
 	fake.connectedUsernameArgsForCall = append(fake.connectedUsernameArgsForCall, struct {
 	}{})
+	stub := fake.ConnectedUsernameStub
+	fakeReturns := fake.connectedUsernameReturns
 	fake.recordInvocation("ConnectedUsername", []interface{}{})
 	fake.connectedUsernameMutex.Unlock()
-	if fake.ConnectedUsernameStub != nil {
-		return fake.ConnectedUsernameStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.connectedUsernameReturns
 	return fakeReturns.result1
 }
 
@@ -357,15 +361,16 @@ func (fake *FakeRemoteRunner) CreateDirectory(arg1 string) error {
 	fake.createDirectoryArgsForCall = append(fake.createDirectoryArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.CreateDirectoryStub
+	fakeReturns := fake.createDirectoryReturns
 	fake.recordInvocation("CreateDirectory", []interface{}{arg1})
 	fake.createDirectoryMutex.Unlock()
-	if fake.CreateDirectoryStub != nil {
-		return fake.CreateDirectoryStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.createDirectoryReturns
 	return fakeReturns.result1
 }
 
@@ -417,15 +422,16 @@ func (fake *FakeRemoteRunner) DirectoryExists(arg1 string) (bool, error) {
 	fake.directoryExistsArgsForCall = append(fake.directoryExistsArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.DirectoryExistsStub
+	fakeReturns := fake.directoryExistsReturns
 	fake.recordInvocation("DirectoryExists", []interface{}{arg1})
 	fake.directoryExistsMutex.Unlock()
-	if fake.DirectoryExistsStub != nil {
-		return fake.DirectoryExistsStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.directoryExistsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -481,15 +487,16 @@ func (fake *FakeRemoteRunner) ExtractAndUpload(arg1 io.Reader, arg2 string) erro
 		arg1 io.Reader
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.ExtractAndUploadStub
+	fakeReturns := fake.extractAndUploadReturns
 	fake.recordInvocation("ExtractAndUpload", []interface{}{arg1, arg2})
 	fake.extractAndUploadMutex.Unlock()
-	if fake.ExtractAndUploadStub != nil {
-		return fake.ExtractAndUploadStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.extractAndUploadReturns
 	return fakeReturns.result1
 }
 
@@ -541,15 +548,16 @@ func (fake *FakeRemoteRunner) FindFiles(arg1 string) ([]string, error) {
 	fake.findFilesArgsForCall = append(fake.findFilesArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.FindFilesStub
+	fakeReturns := fake.findFilesReturns
 	fake.recordInvocation("FindFiles", []interface{}{arg1})
 	fake.findFilesMutex.Unlock()
-	if fake.FindFilesStub != nil {
-		return fake.FindFilesStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.findFilesReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -603,15 +611,16 @@ func (fake *FakeRemoteRunner) IsWindows() (bool, error) {
 	ret, specificReturn := fake.isWindowsReturnsOnCall[len(fake.isWindowsArgsForCall)]
 	fake.isWindowsArgsForCall = append(fake.isWindowsArgsForCall, struct {
 	}{})
+	stub := fake.IsWindowsStub
+	fakeReturns := fake.isWindowsReturns
 	fake.recordInvocation("IsWindows", []interface{}{})
 	fake.isWindowsMutex.Unlock()
-	if fake.IsWindowsStub != nil {
-		return fake.IsWindowsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.isWindowsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -659,15 +668,16 @@ func (fake *FakeRemoteRunner) RemoveDirectory(arg1 string) error {
 	fake.removeDirectoryArgsForCall = append(fake.removeDirectoryArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.RemoveDirectoryStub
+	fakeReturns := fake.removeDirectoryReturns
 	fake.recordInvocation("RemoveDirectory", []interface{}{arg1})
 	fake.removeDirectoryMutex.Unlock()
-	if fake.RemoveDirectoryStub != nil {
-		return fake.RemoveDirectoryStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.removeDirectoryReturns
 	return fakeReturns.result1
 }
 
@@ -720,15 +730,16 @@ func (fake *FakeRemoteRunner) RunScript(arg1 string, arg2 string) (string, error
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.RunScriptStub
+	fakeReturns := fake.runScriptReturns
 	fake.recordInvocation("RunScript", []interface{}{arg1, arg2})
 	fake.runScriptMutex.Unlock()
-	if fake.RunScriptStub != nil {
-		return fake.RunScriptStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.runScriptReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -777,23 +788,25 @@ func (fake *FakeRemoteRunner) RunScriptReturnsOnCall(i int, result1 string, resu
 	}{result1, result2}
 }
 
-func (fake *FakeRemoteRunner) RunScriptWithEnv(arg1 string, arg2 map[string]string, arg3 string) (string, error) {
+func (fake *FakeRemoteRunner) RunScriptWithEnv(arg1 string, arg2 map[string]string, arg3 string, arg4 io.Writer) (string, error) {
 	fake.runScriptWithEnvMutex.Lock()
 	ret, specificReturn := fake.runScriptWithEnvReturnsOnCall[len(fake.runScriptWithEnvArgsForCall)]
 	fake.runScriptWithEnvArgsForCall = append(fake.runScriptWithEnvArgsForCall, struct {
 		arg1 string
 		arg2 map[string]string
 		arg3 string
-	}{arg1, arg2, arg3})
-	fake.recordInvocation("RunScriptWithEnv", []interface{}{arg1, arg2, arg3})
+		arg4 io.Writer
+	}{arg1, arg2, arg3, arg4})
+	stub := fake.RunScriptWithEnvStub
+	fakeReturns := fake.runScriptWithEnvReturns
+	fake.recordInvocation("RunScriptWithEnv", []interface{}{arg1, arg2, arg3, arg4})
 	fake.runScriptWithEnvMutex.Unlock()
-	if fake.RunScriptWithEnvStub != nil {
-		return fake.RunScriptWithEnvStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.runScriptWithEnvReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -803,17 +816,17 @@ func (fake *FakeRemoteRunner) RunScriptWithEnvCallCount() int {
 	return len(fake.runScriptWithEnvArgsForCall)
 }
 
-func (fake *FakeRemoteRunner) RunScriptWithEnvCalls(stub func(string, map[string]string, string) (string, error)) {
+func (fake *FakeRemoteRunner) RunScriptWithEnvCalls(stub func(string, map[string]string, string, io.Writer) (string, error)) {
 	fake.runScriptWithEnvMutex.Lock()
 	defer fake.runScriptWithEnvMutex.Unlock()
 	fake.RunScriptWithEnvStub = stub
 }
 
-func (fake *FakeRemoteRunner) RunScriptWithEnvArgsForCall(i int) (string, map[string]string, string) {
+func (fake *FakeRemoteRunner) RunScriptWithEnvArgsForCall(i int) (string, map[string]string, string, io.Writer) {
 	fake.runScriptWithEnvMutex.RLock()
 	defer fake.runScriptWithEnvMutex.RUnlock()
 	argsForCall := fake.runScriptWithEnvArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
 func (fake *FakeRemoteRunner) RunScriptWithEnvReturns(result1 string, result2 error) {
@@ -848,15 +861,16 @@ func (fake *FakeRemoteRunner) SizeInBytes(arg1 string) (int, error) {
 	fake.sizeInBytesArgsForCall = append(fake.sizeInBytesArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.SizeInBytesStub
+	fakeReturns := fake.sizeInBytesReturns
 	fake.recordInvocation("SizeInBytes", []interface{}{arg1})
 	fake.sizeInBytesMutex.Unlock()
-	if fake.SizeInBytesStub != nil {
-		return fake.SizeInBytesStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.sizeInBytesReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -911,15 +925,16 @@ func (fake *FakeRemoteRunner) SizeOf(arg1 string) (string, error) {
 	fake.sizeOfArgsForCall = append(fake.sizeOfArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.SizeOfStub
+	fakeReturns := fake.sizeOfReturns
 	fake.recordInvocation("SizeOf", []interface{}{arg1})
 	fake.sizeOfMutex.Unlock()
-	if fake.SizeOfStub != nil {
-		return fake.SizeOfStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.sizeOfReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/ssh/fakes/fake_remote_runner_factory.go
+++ b/ssh/fakes/fake_remote_runner_factory.go
@@ -47,15 +47,17 @@ func (fake *FakeRemoteRunnerFactory) Spy(arg1 string, arg2 string, arg3 string, 
 		arg5 []string
 		arg6 ssh.Logger
 	}{arg1, arg2, arg3, arg4, arg5Copy, arg6})
+	stub := fake.Stub
+	returns := fake.returns
 	fake.recordInvocation("RemoteRunnerFactory", []interface{}{arg1, arg2, arg3, arg4, arg5Copy, arg6})
 	fake.mutex.Unlock()
-	if fake.Stub != nil {
-		return fake.Stub(arg1, arg2, arg3, arg4, arg5, arg6)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4, arg5, arg6)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.returns.result1, fake.returns.result2
+	return returns.result1, returns.result2
 }
 
 func (fake *FakeRemoteRunnerFactory) CallCount() int {

--- a/ssh/fakes/fake_ssh_connection.go
+++ b/ssh/fakes/fake_ssh_connection.go
@@ -80,15 +80,16 @@ func (fake *FakeSSHConnection) Run(arg1 string) ([]byte, []byte, int, error) {
 	fake.runArgsForCall = append(fake.runArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.RunStub
+	fakeReturns := fake.runReturns
 	fake.recordInvocation("Run", []interface{}{arg1})
 	fake.runMutex.Unlock()
-	if fake.RunStub != nil {
-		return fake.RunStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3, ret.result4
 	}
-	fakeReturns := fake.runReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3, fakeReturns.result4
 }
 
@@ -150,15 +151,16 @@ func (fake *FakeSSHConnection) Stream(arg1 string, arg2 io.Writer) ([]byte, int,
 		arg1 string
 		arg2 io.Writer
 	}{arg1, arg2})
+	stub := fake.StreamStub
+	fakeReturns := fake.streamReturns
 	fake.recordInvocation("Stream", []interface{}{arg1, arg2})
 	fake.streamMutex.Unlock()
-	if fake.StreamStub != nil {
-		return fake.StreamStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.streamReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -217,15 +219,16 @@ func (fake *FakeSSHConnection) StreamStdin(arg1 string, arg2 io.Reader) ([]byte,
 		arg1 string
 		arg2 io.Reader
 	}{arg1, arg2})
+	stub := fake.StreamStdinStub
+	fakeReturns := fake.streamStdinReturns
 	fake.recordInvocation("StreamStdin", []interface{}{arg1, arg2})
 	fake.streamStdinMutex.Unlock()
-	if fake.StreamStdinStub != nil {
-		return fake.StreamStdinStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3, ret.result4
 	}
-	fakeReturns := fake.streamStdinReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3, fakeReturns.result4
 }
 
@@ -285,15 +288,16 @@ func (fake *FakeSSHConnection) Username() string {
 	ret, specificReturn := fake.usernameReturnsOnCall[len(fake.usernameArgsForCall)]
 	fake.usernameArgsForCall = append(fake.usernameArgsForCall, struct {
 	}{})
+	stub := fake.UsernameStub
+	fakeReturns := fake.usernameReturns
 	fake.recordInvocation("Username", []interface{}{})
 	fake.usernameMutex.Unlock()
-	if fake.UsernameStub != nil {
-		return fake.UsernameStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.usernameReturns
 	return fakeReturns.result1
 }
 

--- a/ssh/fakes/fake_ssh_session.go
+++ b/ssh/fakes/fake_ssh_session.go
@@ -53,15 +53,16 @@ func (fake *FakeSSHSession) Close() error {
 	ret, specificReturn := fake.closeReturnsOnCall[len(fake.closeArgsForCall)]
 	fake.closeArgsForCall = append(fake.closeArgsForCall, struct {
 	}{})
+	stub := fake.CloseStub
+	fakeReturns := fake.closeReturns
 	fake.recordInvocation("Close", []interface{}{})
 	fake.closeMutex.Unlock()
-	if fake.CloseStub != nil {
-		return fake.CloseStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.closeReturns
 	return fakeReturns.result1
 }
 
@@ -106,15 +107,16 @@ func (fake *FakeSSHSession) Run(arg1 string) error {
 	fake.runArgsForCall = append(fake.runArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.RunStub
+	fakeReturns := fake.runReturns
 	fake.recordInvocation("Run", []interface{}{arg1})
 	fake.runMutex.Unlock()
-	if fake.RunStub != nil {
-		return fake.RunStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.runReturns
 	return fakeReturns.result1
 }
 
@@ -173,15 +175,16 @@ func (fake *FakeSSHSession) SendRequest(arg1 string, arg2 bool, arg3 []byte) (bo
 		arg2 bool
 		arg3 []byte
 	}{arg1, arg2, arg3Copy})
+	stub := fake.SendRequestStub
+	fakeReturns := fake.sendRequestReturns
 	fake.recordInvocation("SendRequest", []interface{}{arg1, arg2, arg3Copy})
 	fake.sendRequestMutex.Unlock()
-	if fake.SendRequestStub != nil {
-		return fake.SendRequestStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.sendRequestReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/ssh/remote_runner.go
+++ b/ssh/remote_runner.go
@@ -122,11 +122,7 @@ func (r SshRemoteRunner) RunScriptWithEnv(path string, env map[string]string, la
 	stderr, exitCode, runErr := r.connection.Stream("sudo "+varsList+path, anonymousWriter{write: func(p []byte) (int, error) {
 		n, buffErr := stdoutBuffer.Write(p)
 
-		if label != "" {
-			r.logger.Debug("bbr", "[%s] stdout: %s", label, string(p))
-		} else {
-			r.logger.Debug("bbr", "stdout: %s", string(p))
-		}
+		r.logger.Debug("bbr", "stdout: %s", string(p))
 
 		if buffErr != nil {
 			return n, buffErr
@@ -135,11 +131,7 @@ func (r SshRemoteRunner) RunScriptWithEnv(path string, env map[string]string, la
 		return len(p), nil
 	}})
 
-	if label != "" {
-		r.logger.Debug("bbr", "[%s] stderr: %s", label, string(stderr))
-	} else {
-		r.logger.Debug("bbr", "stderr: %s", string(stderr))
-	}
+	r.logger.Debug("bbr", "stderr: %s", string(stderr))
 
 	stdoutBytes := stdoutBuffer.Bytes()
 

--- a/ssh/remote_runner.go
+++ b/ssh/remote_runner.go
@@ -23,7 +23,7 @@ type RemoteRunner interface {
 	SizeInBytes(path string) (int, error)
 	ChecksumDirectory(path string) (map[string]string, error)
 	RunScript(path, label string) (string, error)
-	RunScriptWithEnv(path string, env map[string]string, label string) (string, error)
+	RunScriptWithEnv(path string, env map[string]string, label string, stdout io.Writer) (string, error)
 	FindFiles(pattern string) ([]string, error)
 	IsWindows() (bool, error)
 }
@@ -107,10 +107,10 @@ func (r SshRemoteRunner) ChecksumDirectory(path string) (map[string]string, erro
 }
 
 func (r SshRemoteRunner) RunScript(path, label string) (string, error) {
-	return r.RunScriptWithEnv(path, map[string]string{}, label)
+	return r.RunScriptWithEnv(path, map[string]string{}, label, io.Discard)
 }
 
-func (r SshRemoteRunner) RunScriptWithEnv(path string, env map[string]string, label string) (string, error) {
+func (r SshRemoteRunner) RunScriptWithEnv(path string, env map[string]string, label string, stdout io.Writer) (string, error) {
 	var varsList = ""
 	for varName, value := range env {
 		varsList = varsList + varName + "=" + value + " "

--- a/ssh/remote_runner.go
+++ b/ssh/remote_runner.go
@@ -128,6 +128,11 @@ func (r SshRemoteRunner) RunScriptWithEnv(path string, env map[string]string, la
 			return n, buffErr
 		}
 
+		n, outErr := stdout.Write(p)
+		if outErr != nil {
+			return n, outErr
+		}
+
 		return len(p), nil
 	}})
 

--- a/ssh/remote_runner.go
+++ b/ssh/remote_runner.go
@@ -123,9 +123,14 @@ func (r SshRemoteRunner) RunScriptWithEnv(path string, env map[string]string, la
 
 	stdoutBytes := stdoutBuffer.Bytes()
 
-	err := r.logAndCheckErrors(stdoutBytes, stderr, exitCode, runErr, label)
-	if err != nil {
-		return "", err
+	r.logOutput(stdoutBytes, stderr, label)
+
+	if runErr != nil {
+		return "", runErr
+	}
+
+	if exitCode != 0 {
+		return "", exitError(stderr, exitCode)
 	}
 
 	return string(stdoutBytes), nil

--- a/ssh/remote_runner.go
+++ b/ssh/remote_runner.go
@@ -116,7 +116,14 @@ func (r SshRemoteRunner) RunScriptWithEnv(path string, env map[string]string, la
 		varsList = varsList + varName + "=" + value + " "
 	}
 
-	return r.runOnInstanceWithLabel("sudo "+varsList+path, label)
+	stdoutput, stderr, exitCode, runErr := r.connection.Run("sudo "+varsList+path)
+
+	err := r.logAndCheckErrors(stdoutput, stderr, exitCode, runErr, label)
+	if err != nil {
+		return "", err
+	}
+
+	return string(stdoutput), nil
 }
 
 func (r SshRemoteRunner) FindFiles(pattern string) ([]string, error) {

--- a/ssh/remote_runner.go
+++ b/ssh/remote_runner.go
@@ -198,13 +198,9 @@ func (r SshRemoteRunner) IsWindows() (bool, error) {
 }
 
 func (r SshRemoteRunner) runOnInstance(cmd string) (string, error) {
-	return r.runOnInstanceWithLabel(cmd, "")
-}
-
-func (r SshRemoteRunner) runOnInstanceWithLabel(cmd, label string) (string, error) {
 	stdout, stderr, exitCode, runErr := r.connection.Run(cmd)
 
-	err := r.logAndCheckErrors(stdout, stderr, exitCode, runErr, label)
+	err := r.logAndCheckErrors(stdout, stderr, exitCode, runErr, "")
 	if err != nil {
 		return "", err
 	}

--- a/ssh/remote_runner_test.go
+++ b/ssh/remote_runner_test.go
@@ -322,7 +322,7 @@ var _ = Describe("SshRemoteRunner", func() {
 				runCommand("echo 'env' > /tmp/example-script")
 				makeAccessibleOnlyByRoot("/tmp/example-script")
 
-				stdout, err := sshRemoteRunner.RunScriptWithEnv("/tmp/example-script", map[string]string{"env1": "foo", "env2": "bar"}, "")
+				stdout, err := sshRemoteRunner.RunScriptWithEnv("/tmp/example-script", map[string]string{"env1": "foo", "env2": "bar"}, "", io.Discard)
 
 				Expect(err).NotTo(HaveOccurred())
 
@@ -335,7 +335,7 @@ var _ = Describe("SshRemoteRunner", func() {
 
 		Context("when the script is not there", func() {
 			It("returns a helpful error", func() {
-				_, err := sshRemoteRunner.RunScriptWithEnv("/tmp/example-script", map[string]string{"env1": "foo", "env2": "bar"}, "")
+				_, err := sshRemoteRunner.RunScriptWithEnv("/tmp/example-script", map[string]string{"env1": "foo", "env2": "bar"}, "", io.Discard)
 
 				Expect(err).To(MatchError(ContainSubstring("command not found")))
 
@@ -347,7 +347,7 @@ var _ = Describe("SshRemoteRunner", func() {
 				runCommand("echo '>&2 echo example script has errorred; exit 12' > /tmp/example-script")
 				runCommand("chmod +x /tmp/example-script")
 
-				_, err := sshRemoteRunner.RunScriptWithEnv("/tmp/example-script", map[string]string{"env1": "foo", "env2": "bar"}, "")
+				_, err := sshRemoteRunner.RunScriptWithEnv("/tmp/example-script", map[string]string{"env1": "foo", "env2": "bar"}, "", io.Discard)
 
 				Expect(err).To(MatchError(ContainSubstring("example script has errorred - exit code 12")))
 
@@ -359,7 +359,7 @@ var _ = Describe("SshRemoteRunner", func() {
 			})
 
 			It("returns an error", func() {
-				_, err := sshRemoteRunner.RunScriptWithEnv("whatever", map[string]string{}, "")
+				_, err := sshRemoteRunner.RunScriptWithEnv("whatever", map[string]string{}, "", io.Discard)
 				Expect(err).To(MatchError(ContainSubstring("ssh.Dial failed")))
 			})
 		})

--- a/ssh/remote_runner_test.go
+++ b/ssh/remote_runner_test.go
@@ -322,11 +322,13 @@ var _ = Describe("SshRemoteRunner", func() {
 				runCommand("echo 'env' > /tmp/example-script")
 				makeAccessibleOnlyByRoot("/tmp/example-script")
 
-				stdout, err := sshRemoteRunner.RunScriptWithEnv("/tmp/example-script", map[string]string{"env1": "foo", "env2": "bar"}, "", io.Discard)
+				stdoutBuffer := &bytes.Buffer{}
+
+				_, err := sshRemoteRunner.RunScriptWithEnv("/tmp/example-script", map[string]string{"env1": "foo", "env2": "bar"}, "", stdoutBuffer)
 
 				Expect(err).NotTo(HaveOccurred())
 
-				Expect(stdout).To(SatisfyAll(
+				Expect(stdoutBuffer.Bytes()).To(SatisfyAll(
 					ContainSubstring("env1=foo"),
 					ContainSubstring("env2=bar"),
 				))

--- a/ssh/remote_runner_test.go
+++ b/ssh/remote_runner_test.go
@@ -324,7 +324,7 @@ var _ = Describe("SshRemoteRunner", func() {
 
 				stdoutBuffer := &bytes.Buffer{}
 
-				_, err := sshRemoteRunner.RunScriptWithEnv("/tmp/example-script", map[string]string{"env1": "foo", "env2": "bar"}, "", stdoutBuffer)
+				err := sshRemoteRunner.RunScriptWithEnv("/tmp/example-script", map[string]string{"env1": "foo", "env2": "bar"}, "", stdoutBuffer)
 
 				Expect(err).NotTo(HaveOccurred())
 
@@ -337,7 +337,7 @@ var _ = Describe("SshRemoteRunner", func() {
 
 		Context("when the script is not there", func() {
 			It("returns a helpful error", func() {
-				_, err := sshRemoteRunner.RunScriptWithEnv("/tmp/example-script", map[string]string{"env1": "foo", "env2": "bar"}, "", io.Discard)
+				err := sshRemoteRunner.RunScriptWithEnv("/tmp/example-script", map[string]string{"env1": "foo", "env2": "bar"}, "", io.Discard)
 
 				Expect(err).To(MatchError(ContainSubstring("command not found")))
 
@@ -349,7 +349,7 @@ var _ = Describe("SshRemoteRunner", func() {
 				runCommand("echo '>&2 echo example script has errorred; exit 12' > /tmp/example-script")
 				runCommand("chmod +x /tmp/example-script")
 
-				_, err := sshRemoteRunner.RunScriptWithEnv("/tmp/example-script", map[string]string{"env1": "foo", "env2": "bar"}, "", io.Discard)
+				err := sshRemoteRunner.RunScriptWithEnv("/tmp/example-script", map[string]string{"env1": "foo", "env2": "bar"}, "", io.Discard)
 
 				Expect(err).To(MatchError(ContainSubstring("example script has errorred - exit code 12")))
 
@@ -361,7 +361,7 @@ var _ = Describe("SshRemoteRunner", func() {
 			})
 
 			It("returns an error", func() {
-				_, err := sshRemoteRunner.RunScriptWithEnv("whatever", map[string]string{}, "", io.Discard)
+				err := sshRemoteRunner.RunScriptWithEnv("whatever", map[string]string{}, "", io.Discard)
 				Expect(err).To(MatchError(ContainSubstring("ssh.Dial failed")))
 			})
 		})


### PR DESCRIPTION
This PR depends on #431 and replaces #426 .

We have heard reports that if a backup or restore script prints out huge amounts of data to stdout, this can cause the BBR CLI to crash.

The reason this happens seems to be that a method in the CLI was effectively buffering all the data from the script's stdout. This PR changes that method so that it streams stdout to an io.Writer, instead of caching and returning it.

Changes to files in the `fakes` directory can be ignored, since they are auto-generated. Each commit keeps all the tests green, and is individually motivated in the commit message.