### PR TITLE
Fix ssh issues with Windows Stemcells 2019.46+

### DIFF
--- a/bosh/client.go
+++ b/bosh/client.go
@@ -15,6 +15,19 @@ import (
 	gossh "golang.org/x/crypto/ssh"
 )
 
+func SupportedHostKeyAlgorithms() []string {
+	return []string{
+		gossh.KeyAlgoRSA,
+		gossh.KeyAlgoRSASHA256,
+		gossh.KeyAlgoRSASHA512,
+		gossh.KeyAlgoDSA,
+		gossh.KeyAlgoECDSA256,
+		gossh.KeyAlgoECDSA384,
+		gossh.KeyAlgoECDSA521,
+		gossh.KeyAlgoED25519,
+	}
+}
+
 //go:generate counterfeiter -o fakes/fake_bosh_client.go . BoshClient
 type BoshClient interface {
 	FindInstances(deploymentName string) ([]orchestrator.Instance, error)
@@ -111,7 +124,8 @@ func (c Client) FindInstances(deploymentName string) ([]orchestrator.Instance, e
 				return nil, errors.Wrap(err, "ssh.NewConnection.ParseAuthorizedKey failed")
 			}
 
-			remoteRunner, err := c.RemoteRunnerFactory(host.Host, host.Username, privateKey, gossh.FixedHostKey(hostPublicKey), []string{hostPublicKey.Type()}, c.Logger)
+			hostKeyAlgorithms := append([]string{hostPublicKey.Type()}, SupportedHostKeyAlgorithms()...)
+			remoteRunner, err := c.RemoteRunnerFactory(host.Host, host.Username, privateKey, gossh.FixedHostKey(hostPublicKey), hostKeyAlgorithms, c.Logger)
 			if err != nil {
 				cleanupAlreadyMadeConnections(deployment, slugs, sshOpts)
 				return nil, errors.Wrap(err, "failed to connect using ssh")

--- a/bosh/client_test.go
+++ b/bosh/client_test.go
@@ -39,6 +39,7 @@ var _ = Describe("Director", func() {
 
 	var hostsPublicKey = "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAklOUpkDHrfHY17SbrmTIpNLTGK9Tjom/BWDSUGPl+nafzlHDTYW7hdI4yZ5ew18JH4JW9jbhUFrviQzM7xlELEVf4h9lFX5QVkbPppSwg0cda3Pbv7kOdJ/MTyBlWXFCR+HAo3FXRitBqxiX1nKhXpHAZsMciLq8V6RjsNAQwdsdMFvSlVK/7XAt3FaoJoAsncM1Q9x5+3V0Ww68/eIFmb1zuUFljQJKprrX88XypNDvjYNby6vw/Pb0rwert/EnmZ+AW4OZPnTPI89ZPmVMLuayrD2cE86Z/il8b+gw3r3+1nKatmIkjn2so1d01QraTlMqVSsbxNrRFi9wrf+M7Q== schacon@mylaptop.local"
 	var hostKeyAlgorithm []string
+	var acceptedHostKeyAlgorithms []string
 
 	var b bosh.BoshClient
 
@@ -63,6 +64,7 @@ var _ = Describe("Director", func() {
 		hostPublicKey, _, _, _, err := gossh.ParseAuthorizedKey([]byte(hostsPublicKey))
 		Expect(err).NotTo(HaveOccurred())
 		hostKeyAlgorithm = []string{hostPublicKey.Type()}
+		acceptedHostKeyAlgorithms = append(hostKeyAlgorithm, bosh.SupportedHostKeyAlgorithms()...)
 
 		combinedLog := log.New(io.MultiWriter(GinkgoWriter, logStream), "[bosh-package] ", log.Lshortfile)
 		boshLogger = boshlog.New(boshlog.LevelDebug, combinedLog)
@@ -174,7 +176,7 @@ var _ = Describe("Director", func() {
 				Expect(host).To(Equal("10.0.0.0"))
 				Expect(username).To(Equal("username"))
 				Expect(privateKey).To(Equal("private_key"))
-				Expect(hostPublicKeyAlgorithm).To(Equal(hostKeyAlgorithm))
+				Expect(hostPublicKeyAlgorithm).To(Equal(acceptedHostKeyAlgorithms))
 				Expect(logger).To(Equal(boshLogger))
 			})
 		})
@@ -203,7 +205,7 @@ var _ = Describe("Director", func() {
 				Expect(host).To(Equal("10.0.0.0:3457"))
 				Expect(username).To(Equal("username"))
 				Expect(privateKey).To(Equal("private_key"))
-				Expect(hostPublicKeyAlgorithm).To(Equal(hostKeyAlgorithm))
+				Expect(hostPublicKeyAlgorithm).To(Equal(acceptedHostKeyAlgorithms))
 				Expect(logger).To(Equal(boshLogger))
 			})
 		})
@@ -336,14 +338,14 @@ var _ = Describe("Director", func() {
 				Expect(host).To(Equal("10.0.0.1"))
 				Expect(username).To(Equal("username"))
 				Expect(privateKey).To(Equal("private_key"))
-				Expect(hostPublicKeyAlgorithm).To(Equal(hostKeyAlgorithm))
+				Expect(hostPublicKeyAlgorithm).To(Equal(acceptedHostKeyAlgorithms))
 				Expect(logger).To(Equal(boshLogger))
 
 				host, username, privateKey, _, hostPublicKeyAlgorithm, logger = remoteRunnerFactory.ArgsForCall(1)
 				Expect(host).To(Equal("10.0.0.2"))
 				Expect(username).To(Equal("username"))
 				Expect(privateKey).To(Equal("private_key"))
-				Expect(hostPublicKeyAlgorithm).To(Equal(hostKeyAlgorithm))
+				Expect(hostPublicKeyAlgorithm).To(Equal(acceptedHostKeyAlgorithms))
 				Expect(logger).To(Equal(boshLogger))
 			})
 
@@ -629,21 +631,21 @@ var _ = Describe("Director", func() {
 				Expect(host).To(Equal("10.0.0.1"))
 				Expect(username).To(Equal("username"))
 				Expect(privateKey).To(Equal("private_key"))
-				Expect(hostPublicKeyAlgorithm).To(Equal(hostKeyAlgorithm))
+				Expect(hostPublicKeyAlgorithm).To(Equal(acceptedHostKeyAlgorithms))
 				Expect(logger).To(Equal(boshLogger))
 
 				host, username, privateKey, _, hostPublicKeyAlgorithm, logger = remoteRunnerFactory.ArgsForCall(1)
 				Expect(host).To(Equal("10.0.0.3"))
 				Expect(username).To(Equal("username"))
 				Expect(privateKey).To(Equal("private_key"))
-				Expect(hostPublicKeyAlgorithm).To(Equal(hostKeyAlgorithm))
+				Expect(hostPublicKeyAlgorithm).To(Equal(acceptedHostKeyAlgorithms))
 				Expect(logger).To(Equal(boshLogger))
 
 				host, username, privateKey, _, hostPublicKeyAlgorithm, logger = remoteRunnerFactory.ArgsForCall(2)
 				Expect(host).To(Equal("10.0.0.4"))
 				Expect(username).To(Equal("username"))
 				Expect(privateKey).To(Equal("private_key"))
-				Expect(hostPublicKeyAlgorithm).To(Equal(hostKeyAlgorithm))
+				Expect(hostPublicKeyAlgorithm).To(Equal(acceptedHostKeyAlgorithms))
 				Expect(logger).To(Equal(boshLogger))
 			})
 


### PR DESCRIPTION
[#182248334]

Newer versions of the Stemcells don't list `ssh-rsa` algorithm
as an option while performing the handshake process.

This change remains backward compatible while also allowing
handshake to succeed by listing other accepted algorithms.

SSH implementation will transparently choose one that works
taking into account:
- Order in which algorithms were specified
- Algorithms supported by both client and server
- Specified Host and public key format
- Additional ClientConfig settings