### PR TITLE
Fail restore only for mismatching checksums

### DIFF
--- a/orchestrator/backup_download_executable.go
+++ b/orchestrator/backup_download_executable.go
@@ -96,7 +96,7 @@ func (e BackupDownloadExecutable) compareChecksums(localBackup Backup, remoteBac
 	e.Logger.Debug("bbr", "Comparing shasums")
 
 	match, mismatchedFiles := localChecksum.Match(remoteChecksum)
-	if !match {
+	if !match && len(mismatchedFiles) > 0 {
 		e.Logger.Debug("bbr", "Checksums didn't match for:")
 		e.Logger.Debug("bbr", fmt.Sprintf("%v\n", mismatchedFiles))
 


### PR DESCRIPTION
Allow missing checksums in metadata and only fail if checksums really differ

Should fix #724 