### PR TITLE
Fix evergreen s3-validator pipeline

### DIFF
--- a/ci/pipelines/bbr/pipeline.yml
+++ b/ci/pipelines/bbr/pipeline.yml
@@ -751,7 +751,7 @@ jobs:
             INCLUDE_DEPLOYMENT_TESTCASE: true
             INCLUDE_TRUNCATE_DB_BLOBSTORE_TESTCASE: false
             INCLUDE_CREDHUB_TESTCASE: false
-            TIMEOUT_IN_MINUTES: 720
+            TIMEOUT_IN_MINUTES: 17_280 # 48h
           output_mapping:
             config: b-drats-config
         - load_var: env-metadata

--- a/ci/pipelines/bbr/pipeline.yml
+++ b/ci/pipelines/bbr/pipeline.yml
@@ -33,7 +33,7 @@ groups:
   - build-rc
   - run-drats
   - run-b-drats
-  - update-tracker
+  - merge-pr
   - publish-to-github
   - upload-to-tanzunet
   - update-homebrew-formula
@@ -48,7 +48,7 @@ groups:
   - system-test-deployment
   - system-test-director
   - unclaim-env
-  - update-tracker
+  - merge-pr
 
 - name: release
   jobs:
@@ -599,7 +599,7 @@ jobs:
       action: unclaim
       env_file: env-pool/metadata
 
-- name: update-tracker
+- name: merge-pr
   plan:
   - in_parallel:
     - get: latest-pull-request

--- a/ci/tasks/bbr-s3-config-validator-validate-aws-s3-config/task.sh
+++ b/ci/tasks/bbr-s3-config-validator-validate-aws-s3-config/task.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -eu
+set -euo pipefail
 
 pool_metadata="env-pool/metadata"
 


### PR DESCRIPTION
We're seeing some CI runs like this[1] which ought to fail, but don't. This is because CI is currently only tracking whether or not our secrets redactor succeeds, not whether the underlying command succeeds.

We can fix this by using `set -o pipefail` at the top of the bash script.

[1] https://ci.cryo.cf-app.com/teams/bosh-backup-restore/pipelines/bbr-cli/jobs/test-build-s3-config-validator/builds/841