### PR TITLE
fix: Make validator work with instance profiles

### DIFF
--- a/s3-config-validator/src/cmd/main.go
+++ b/s3-config-validator/src/cmd/main.go
@@ -26,11 +26,11 @@ type CommandParams struct {
 func main() {
 	commandParams := parseParams()
 
-	config, err := config.Read(commandParams.ConfigPath, commandParams.Versioned)
+	validatedConfig, err := config.Read(commandParams.ConfigPath, commandParams.Versioned)
 
 	printHeader(commandParams, commandParams.Versioned)
 
-	configPrinter.PrintConfig(os.Stdout, config)
+	configPrinter.PrintConfig(os.Stdout, validatedConfig)
 
 	if err != nil {
 		fmt.Printf("%v\n", err.Error())
@@ -39,7 +39,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if !isValid(config, commandParams.ReadOnlyValidation, commandParams.Versioned) {
+	if !isValid(validatedConfig, commandParams.ReadOnlyValidation, commandParams.Versioned) {
 		fmt.Println("Bad config")
 		printHints(commandParams)
 		os.Exit(1)

--- a/s3-config-validator/src/internal/config/config.go
+++ b/s3-config-validator/src/internal/config/config.go
@@ -85,12 +85,14 @@ func validateConfig(config Config, versioned bool) error {
 		}
 
 		if !versioned {
-			if liveBucket.Backup.Name == "" {
-				emptyFieldNames = append(emptyFieldNames, liveBucketName+".backup.name")
-			}
+			if liveBucket.Backup != nil {
+				if liveBucket.Backup.Name == "" {
+					emptyFieldNames = append(emptyFieldNames, liveBucketName+".backup.name")
+				}
 
-			if liveBucket.Backup.Region == "" {
-				emptyFieldNames = append(emptyFieldNames, liveBucketName+".backup.region")
+				if liveBucket.Backup.Region == "" {
+					emptyFieldNames = append(emptyFieldNames, liveBucketName+".backup.region")
+				}
 			}
 		}
 

--- a/s3-config-validator/src/internal/config/config.go
+++ b/s3-config-validator/src/internal/config/config.go
@@ -105,11 +105,7 @@ func validateConfig(config Config, versioned bool) error {
 		return fmt.Errorf("invalid config: fields %v are empty", emptyFieldNames)
 	}
 	if len(bucketsWithTooManyCreds) > 0 {
-		explanation := ""
-		for _, bucket := range bucketsWithTooManyCreds {
-			explanation += fmt.Sprintf(" if %[1]s.use_iam_profile is true, then %[1]s.aws_access_key_id and %[1]s.aws_secret_access_key should be empty", bucket)
-		}
-		return fmt.Errorf("invalid config:%s", explanation)
+		return fmt.Errorf("invalid config: because use_iam_profile is set to true, there should be no aws_access_key_id or aws_secret_access_key in the following buckets: %v", bucketsWithTooManyCreds)
 	}
 	if len(missingUnversionedBackupBuckets) > 0 {
 		return fmt.Errorf("invalid config: backup buckets must be specified when taking unversioned backups. The following buckets are missing backup buckets: %v", missingUnversionedBackupBuckets)

--- a/s3-config-validator/src/internal/config/config.go
+++ b/s3-config-validator/src/internal/config/config.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"sort"
 )
 
 var errEmptyJSON = errors.New("invalid config: json was empty")
@@ -101,14 +102,22 @@ func validateConfig(config Config, versioned bool) error {
 
 	}
 
+	errorMessage := ""
 	if len(emptyFieldNames) > 0 {
-		return fmt.Errorf("invalid config: fields %v are empty", emptyFieldNames)
+		sort.Sort(sort.StringSlice(emptyFieldNames))
+		errorMessage += fmt.Sprintf("invalid config: fields %v are empty\n", emptyFieldNames)
 	}
 	if len(bucketsWithTooManyCreds) > 0 {
-		return fmt.Errorf("invalid config: because use_iam_profile is set to true, there should be no aws_access_key_id or aws_secret_access_key in the following buckets: %v", bucketsWithTooManyCreds)
+		sort.Sort(sort.StringSlice(bucketsWithTooManyCreds))
+		errorMessage += fmt.Sprintf("invalid config: because use_iam_profile is set to true, there should be no aws_access_key_id or aws_secret_access_key in the following buckets: %v\n", bucketsWithTooManyCreds)
 	}
 	if len(missingUnversionedBackupBuckets) > 0 {
-		return fmt.Errorf("invalid config: backup buckets must be specified when taking unversioned backups. The following buckets are missing backup buckets: %v", missingUnversionedBackupBuckets)
+		sort.Sort(sort.StringSlice(missingUnversionedBackupBuckets))
+		errorMessage += fmt.Sprintf("invalid config: backup buckets must be specified when taking unversioned backups. The following buckets are missing backup buckets: %v\n", missingUnversionedBackupBuckets)
+	}
+
+	if errorMessage != "" {
+		return fmt.Errorf(errorMessage)
 	}
 
 	return nil

--- a/s3-config-validator/src/internal/config/config.go
+++ b/s3-config-validator/src/internal/config/config.go
@@ -20,6 +20,7 @@ type LiveBucket struct {
 	Secret   string       `json:"aws_secret_access_key"`
 	Endpoint string       `json:"endpoint"`
 	Backup   *BackupBucket `json:"backup,omitempty"`
+	UseIAMProfile bool `json:"use_iam_profile"`
 }
 
 type BackupBucket struct {
@@ -68,13 +69,16 @@ func validateConfig(config Config, versioned bool) error {
 			emptyFieldNames = append(emptyFieldNames, liveBucketName+".region")
 		}
 
-		if liveBucket.ID == "" {
-			emptyFieldNames = append(emptyFieldNames, liveBucketName+".aws_access_key_id")
+		if ! liveBucket.UseIAMProfile {
+			if liveBucket.ID == "" {
+				emptyFieldNames = append(emptyFieldNames, liveBucketName+".aws_access_key_id")
+			}
+
+			if liveBucket.Secret == "" {
+				emptyFieldNames = append(emptyFieldNames, liveBucketName+".aws_secret_access_key")
+			}
 		}
 
-		if liveBucket.Secret == "" {
-			emptyFieldNames = append(emptyFieldNames, liveBucketName+".aws_secret_access_key")
-		}
 		if !versioned {
 			if liveBucket.Backup.Name == "" {
 				emptyFieldNames = append(emptyFieldNames, liveBucketName+".backup.name")

--- a/s3-config-validator/src/internal/config/config_test.go
+++ b/s3-config-validator/src/internal/config/config_test.go
@@ -47,6 +47,16 @@ var _ = Describe("Config", func() {
         "region": ""
     }
 	}`
+		invalidIAMPlusCredsConfig := `{
+    "buildpacks": {
+        "aws_access_key_id": "test_access_key_id",
+        "aws_secret_access_key": "test_secret_access_key",
+        "endpoint": "test_endpoint",
+        "name": "test_name",
+        "region": "test_region",
+        "use_iam_profile": true
+    }
+}`
 
 		Context("given a path to an existing, readable file", func() {
 			Context("contents are valid", func() {
@@ -126,6 +136,20 @@ var _ = Describe("Config", func() {
 							" [buildpacks.name buildpacks.region buildpacks.aws_access_key_id" +
 							" buildpacks.aws_secret_access_key]" +
 							" are empty"))
+						Expect(conf).To(Equal(config.Config{}))
+					})
+				})
+
+				When("we try to use IAM and a Secret Access Key at the same time", func() {
+					It("returns a helpful error", func() {
+						testFile := CreateFile(invalidIAMPlusCredsConfig)
+						defer DeleteFile(testFile)
+
+						conf, err := config.Read(testFile, true)
+
+						Expect(err).To(MatchError("invalid config: if buildpacks.use_iam_profile" +
+							" is true, then buildpacks.aws_access_key_id and"+
+							" buildpacks.aws_secret_access_key should be empty"))
 						Expect(conf).To(Equal(config.Config{}))
 					})
 				})

--- a/s3-config-validator/src/internal/config/config_test.go
+++ b/s3-config-validator/src/internal/config/config_test.go
@@ -249,7 +249,21 @@ var _ = Describe("Config", func() {
         "endpoint": "test_endpoint",
         "name": "test_name",
         "region": "test_region",
-        "use_iam_profile": true
+        "use_iam_profile": true,
+        "backup": {
+            "name": "another_test_name",
+            "region": "another_test_region"
+        }
+    }
+}`
+
+		invalidMissingBackupConfig := `{
+    "buildpacks": {
+        "aws_access_key_id": "test_access_key_id",
+        "aws_secret_access_key": "test_secret_access_key",
+        "endpoint": "test_endpoint",
+        "name": "test_name",
+        "region": "test_region"
     }
 }`
 
@@ -353,6 +367,18 @@ var _ = Describe("Config", func() {
 						Expect(err).To(MatchError("invalid config: if buildpacks.use_iam_profile" +
 							" is true, then buildpacks.aws_access_key_id and"+
 							" buildpacks.aws_secret_access_key should be empty"))
+						Expect(conf).To(Equal(config.Config{}))
+					})
+				})
+
+				When("our unversioned bucket config is missing the backup buckets", func() {
+					It("returns a helpful error", func() {
+						testFile := CreateFile(invalidMissingBackupConfig)
+						defer DeleteFile(testFile)
+
+						conf, err := config.Read(testFile, false)
+
+						Expect(err).To(MatchError("invalid config: backup buckets must be specified when taking unversioned backups. The following buckets are missing backup buckets: [buildpacks]"))
 						Expect(conf).To(Equal(config.Config{}))
 					})
 				})

--- a/s3-config-validator/src/internal/config/config_test.go
+++ b/s3-config-validator/src/internal/config/config_test.go
@@ -148,9 +148,7 @@ var _ = Describe("Config", func() {
 
 						conf, err := config.Read(testFile, true)
 
-						Expect(err).To(MatchError("invalid config: if buildpacks.use_iam_profile" +
-							" is true, then buildpacks.aws_access_key_id and"+
-							" buildpacks.aws_secret_access_key should be empty"))
+						Expect(err).To(MatchError("invalid config: because use_iam_profile is set to true, there should be no aws_access_key_id or aws_secret_access_key in the following buckets: [buildpacks]"))
 						Expect(conf).To(Equal(config.Config{}))
 					})
 				})
@@ -364,9 +362,7 @@ var _ = Describe("Config", func() {
 
 						conf, err := config.Read(testFile, false)
 
-						Expect(err).To(MatchError("invalid config: if buildpacks.use_iam_profile" +
-							" is true, then buildpacks.aws_access_key_id and"+
-							" buildpacks.aws_secret_access_key should be empty"))
+						Expect(err).To(MatchError("invalid config: because use_iam_profile is set to true, there should be no aws_access_key_id or aws_secret_access_key in the following buckets: [buildpacks]"))
 						Expect(conf).To(Equal(config.Config{}))
 					})
 				})

--- a/s3-config-validator/src/internal/config/config_test.go
+++ b/s3-config-validator/src/internal/config/config_test.go
@@ -47,6 +47,7 @@ var _ = Describe("Config", func() {
         "region": ""
     }
 	}`
+
 		invalidIAMPlusCredsConfig := `{
     "buildpacks": {
         "aws_access_key_id": "test_access_key_id",
@@ -241,6 +242,17 @@ var _ = Describe("Config", func() {
     }
 	}`
 
+		invalidIAMPlusCredsConfig := `{
+    "buildpacks": {
+        "aws_access_key_id": "test_access_key_id",
+        "aws_secret_access_key": "test_secret_access_key",
+        "endpoint": "test_endpoint",
+        "name": "test_name",
+        "region": "test_region",
+        "use_iam_profile": true
+    }
+}`
+
 		Context("given a path to an existing, readable file", func() {
 			Context("contents are valid", func() {
 				It("reads the file contents", func() {
@@ -327,6 +339,20 @@ var _ = Describe("Config", func() {
 							" [buildpacks.name buildpacks.region buildpacks.aws_access_key_id" +
 							" buildpacks.aws_secret_access_key buildpacks.backup.name buildpacks.backup.region]" +
 							" are empty"))
+						Expect(conf).To(Equal(config.Config{}))
+					})
+				})
+
+				When("we try to use IAM and a Secret Access Key at the same time", func() {
+					It("returns a helpful error", func() {
+						testFile := CreateFile(invalidIAMPlusCredsConfig)
+						defer DeleteFile(testFile)
+
+						conf, err := config.Read(testFile, false)
+
+						Expect(err).To(MatchError("invalid config: if buildpacks.use_iam_profile" +
+							" is true, then buildpacks.aws_access_key_id and"+
+							" buildpacks.aws_secret_access_key should be empty"))
 						Expect(conf).To(Equal(config.Config{}))
 					})
 				})

--- a/s3-config-validator/src/internal/configPrinter/configPrinter_test.go
+++ b/s3-config-validator/src/internal/configPrinter/configPrinter_test.go
@@ -85,7 +85,8 @@ var _ = Describe("PrintConfig", func() {
       "backup": {
         "name": "testBackupName",
         "region": "testBackupRegion"
-      }
+      },
+      "use_iam_profile": false
     }
   }`
 				PrintConfig(writer, validConfig)
@@ -106,7 +107,8 @@ var _ = Describe("PrintConfig", func() {
       "backup": {
         "name": "testBackupName",
         "region": "testBackupRegion"
-      }
+      },
+      "use_iam_profile": false
     },
     "Test Resource 2": {
       "name": "testName",
@@ -117,7 +119,8 @@ var _ = Describe("PrintConfig", func() {
       "backup": {
         "name": "testBackupName",
         "region": "testBackupRegion"
-      }
+      },
+      "use_iam_profile": false
     }
   }`
 				PrintConfig(writer, validConfigWithMultipleBuckets)
@@ -184,7 +187,8 @@ var _ = Describe("PrintConfig", func() {
       "region": "testRegion",
       "aws_access_key_id": "testID",
       "aws_secret_access_key": "testSecret",
-      "endpoint": "testEndpoint"
+      "endpoint": "testEndpoint",
+      "use_iam_profile": false
     }
   }`
 				PrintConfig(writer, validConfig)
@@ -201,14 +205,16 @@ var _ = Describe("PrintConfig", func() {
       "region": "testRegion",
       "aws_access_key_id": "testID",
       "aws_secret_access_key": "testSecret",
-      "endpoint": "testEndpoint"
+      "endpoint": "testEndpoint",
+      "use_iam_profile": false
     },
     "Test Resource 2": {
       "name": "testName",
       "region": "testRegion",
       "aws_access_key_id": "testID",
       "aws_secret_access_key": "testSecret",
-      "endpoint": "testEndpoint"
+      "endpoint": "testEndpoint",
+      "use_iam_profile": false
     }
   }`
 				PrintConfig(writer, validConfigWithMultipleBuckets)

--- a/s3-config-validator/src/internal/runner/export_test.go
+++ b/s3-config-validator/src/internal/runner/export_test.go
@@ -4,8 +4,8 @@ import "github.com/cloudfoundry-incubator/bosh-backup-and-restore/s3-config-vali
 
 var NewS3ClientImpl = newS3Client
 
-type NewS3Client func(region, endpoint, id, secret string) (*s3.S3Client, error)
+type NewS3Client func(region, endpoint, id, secret string, useIAMProfile bool) (*s3.S3Client, error)
+
 func SetNewS3Client(s3Client NewS3Client) {
 	injectableS3Client = s3Client
 }
-

--- a/s3-config-validator/src/internal/runner/runner.go
+++ b/s3-config-validator/src/internal/runner/runner.go
@@ -45,23 +45,23 @@ func (b Bucket) String() string {
 func (r *ProbeRunner) Run() (succeeded bool) {
 	succeeded = true
 
-	fmt.Fprintf(r.Writer, "Validating %s ...\n", r.Bucket)
+	_, _ = fmt.Fprintf(r.Writer, "Validating %s ...\n", r.Bucket)
 
-	for _, probe := range r.ProbeSet {
-		fmt.Fprintf(r.Writer, " * %s ... ", probe.Name)
+	for _, namedProbe := range r.ProbeSet {
+		_, _ = fmt.Fprintf(r.Writer, " * %s ... ", namedProbe.Name)
 
-		err := probe.Probe(r.Bucket.Name)
+		err := namedProbe.Probe(r.Bucket.Name)
 
 		if err != nil {
 			succeeded = false
 
-			fmt.Fprintf(r.Writer, "No [reason: %s]\n", err.Error())
+			_, _ = fmt.Fprintf(r.Writer, "No [reason: %s]\n", err.Error())
 		} else {
-			fmt.Fprint(r.Writer, "Yes\n")
+			_, _ = fmt.Fprint(r.Writer, "Yes\n")
 		}
 	}
 
-	fmt.Fprintf(r.Writer, "\n")
+	_, _ = fmt.Fprintf(r.Writer, "\n")
 
 	return
 }
@@ -118,5 +118,5 @@ func NewProbeRunner(region, endpoint, id, secret string, bucket Bucket, readOnly
 }
 
 func newS3Client(region, endpoint, id, secret string, useIAMProfile bool) (*s3.S3Client, error) {
-	return s3.NewS3Client(region, endpoint, id, secret, false)
+	return s3.NewS3Client(region, endpoint, id, secret, useIAMProfile)
 }

--- a/s3-config-validator/src/internal/runner/runner.go
+++ b/s3-config-validator/src/internal/runner/runner.go
@@ -2,11 +2,11 @@ package runner
 
 import (
 	"fmt"
-	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/s3-config-validator/src/internal/config"
 	"io"
 	"os"
 	"strings"
 
+	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/s3-config-validator/src/internal/config"
 	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/s3-config-validator/src/internal/probe"
 	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/s3-config-validator/src/internal/s3"
 )

--- a/s3-config-validator/src/internal/runner/runner.go
+++ b/s3-config-validator/src/internal/runner/runner.go
@@ -81,6 +81,7 @@ func NewProbeRunners(resource string, bucket config.LiveBucket, readOnly, versio
 		},
 		readOnly,
 		versioned,
+		bucket.UseIAMProfile,
 	)
 
 	if !versioned {
@@ -93,6 +94,7 @@ func NewProbeRunners(resource string, bucket config.LiveBucket, readOnly, versio
 			},
 			readOnly,
 			false,
+			bucket.UseIAMProfile,
 		)
 		return []ProbeRunner{liveProbeRunner, backupProbeRunner}
 	}
@@ -103,8 +105,8 @@ func NewProbeRunners(resource string, bucket config.LiveBucket, readOnly, versio
 
 var injectableS3Client = newS3Client
 
-func NewProbeRunner(region, endpoint, id, secret string, bucket Bucket, readOnly, versioned bool) ProbeRunner {
-	s3Client, _ := injectableS3Client(region, endpoint, id, secret)
+func NewProbeRunner(region, endpoint, id, secret string, bucket Bucket, readOnly, versioned, useIAMProfile bool) ProbeRunner {
+	s3Client, _ := injectableS3Client(region, endpoint, id, secret, useIAMProfile)
 
 	probeSet := probe.NewSet(s3Client, readOnly, versioned)
 
@@ -115,6 +117,6 @@ func NewProbeRunner(region, endpoint, id, secret string, bucket Bucket, readOnly
 	}
 }
 
-func newS3Client(region, endpoint, id, secret string) (*s3.S3Client, error) {
+func newS3Client(region, endpoint, id, secret string, useIAMProfile bool) (*s3.S3Client, error) {
 	return s3.NewS3Client(region, endpoint, id, secret, false)
 }

--- a/s3-config-validator/src/internal/runner/runner.go
+++ b/s3-config-validator/src/internal/runner/runner.go
@@ -116,5 +116,5 @@ func NewProbeRunner(region, endpoint, id, secret string, bucket Bucket, readOnly
 }
 
 func newS3Client(region, endpoint, id, secret string) (*s3.S3Client, error) {
-	return s3.NewS3Client(region, endpoint, id, secret)
+	return s3.NewS3Client(region, endpoint, id, secret, false)
 }

--- a/s3-config-validator/src/internal/s3/export_test.go
+++ b/s3-config-validator/src/internal/s3/export_test.go
@@ -1,0 +1,13 @@
+package s3
+
+import (
+	"github.com/aws/aws-sdk-go/aws/client"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
+)
+
+type CredIAMProvider = func(c client.ConfigProvider, options ...func(*ec2rolecreds.EC2RoleProvider)) *credentials.Credentials
+
+func SetCredIAMProvider(provider CredIAMProvider) {
+	injectableCredIAMProvider = provider
+}


### PR DESCRIPTION
In the validator, when IAM profile is set in the configuration:
- validate presence of backup buckets for un-versioned buckets
- clarify error messages
- in order to avoid confusion, prevent the following values from being set:
  - AWS credentials
  - endpoint
 
[#184963912]