### PR TITLE
Changed to use cryo-essentials - the cf6 version has gone

### DIFF
--- a/ci/tasks/bbr-s3-config-validator-validate-aws-s3-config/task.yml
+++ b/ci/tasks/bbr-s3-config-validator-validate-aws-s3-config/task.yml
@@ -4,7 +4,8 @@ platform: linux
 image_resource:
   type: registry-image
   source: 
-    repository: cryogenics/essentials-cf6
+    repository: cryogenics/essentials
+    tag: 0.1.50
 
 inputs:
 - name: env-pool

--- a/ci/tasks/bbr-system-deployment/task.yml
+++ b/ci/tasks/bbr-system-deployment/task.yml
@@ -3,7 +3,9 @@ platform: linux
 
 image_resource:
   type: registry-image
-  source: {repository: cryogenics/essentials-cf6}
+  source: 
+    repository: cryogenics/essentials
+    tag: 0.1.50
 
 inputs:
 - name: bosh-backup-and-restore

--- a/ci/tasks/bbr-upload-system-test-releases/task.yml
+++ b/ci/tasks/bbr-upload-system-test-releases/task.yml
@@ -3,7 +3,9 @@ platform: linux
 
 image_resource:
   type: registry-image
-  source: {repository: cryogenics/essentials-cf6}
+  source: 
+    repository: cryogenics/essentials
+    tag: 0.1.50
 
 inputs:
 - name: bbr-deployment-test-releases


### PR DESCRIPTION
The CI is breaking because it references a cryo-essentials-cf6 image, which has now been deleted.

Changed to reference the latest cryo-essentials image