### PR TITLE
backup-and-restore-docker-image use latest BOSH CLI

### DIFF
--- a/ci/images/backup-and-restore-minimal/Dockerfile
+++ b/ci/images/backup-and-restore-minimal/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.20.5 as go-binary
 FROM ubuntu:bionic
 
 ENV cf_cli_version 7.3.0
-ENV bosh_cli_version 6.0.0
+ENV bosh_cli_version 7.2.3
 ENV om_cli_version 0.42.0
 ENV om_cli_6_version 6.2.0
 


### PR DESCRIPTION
We need the latest BOSH CLI to support IAM assumed role