### PR TITLE
chore: incorporate cf-webmock in this repo

### DIFF
--- a/bosh/build_client_test.go
+++ b/bosh/build_client_test.go
@@ -5,14 +5,14 @@ import (
 	"log"
 	"net/http/httptest"
 
+	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/internal/cf-webmock/mockhttp"
 	boshlog "github.com/cloudfoundry/bosh-utils/logger"
-	"github.com/pivotal-cf-experimental/cf-webmock/mockhttp"
 
+	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/internal/cf-webmock/mockbosh"
+	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/internal/cf-webmock/mockuaa"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
-	"github.com/pivotal-cf-experimental/cf-webmock/mockbosh"
-	"github.com/pivotal-cf-experimental/cf-webmock/mockuaa"
 )
 
 var _ = Describe("BuildClient", func() {

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.27.10
-	github.com/pivotal-cf-experimental/cf-webmock v0.0.0-20190222120028-6bf93e3bc5ed
 	github.com/pkg/errors v0.9.1
 	github.com/urfave/cli v1.22.14
 	golang.org/x/crypto v0.11.0

--- a/go.sum
+++ b/go.sum
@@ -99,8 +99,6 @@ github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7J
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.27.10 h1:naR28SdDFlqrG6kScpT8VWpu1xWY5nJRCF3XaYyBjhI=
 github.com/onsi/gomega v1.27.10/go.mod h1:RsS8tutOdbdgzbPtzzATp12yT7kM5I5aElG3evPbQ0M=
-github.com/pivotal-cf-experimental/cf-webmock v0.0.0-20190222120028-6bf93e3bc5ed h1:K0oJgdpc9IIEOfHTSltxdDiMMt+niA8vzKSzCRL+Aig=
-github.com/pivotal-cf-experimental/cf-webmock v0.0.0-20190222120028-6bf93e3bc5ed/go.mod h1:DEHca28ocAPwhwC1trOrUzwjjSnQhxHAtNrvU9RNcj8=
 github.com/pivotal-cf/paraphernalia v0.0.0-20180203224945-a64ae2051c20 h1:DR5eMfe2+6GzLkVyWytdtgUxgbPiOfvKDuqityTV3y8=
 github.com/pivotal-cf/paraphernalia v0.0.0-20180203224945-a64ae2051c20/go.mod h1:Y3IqE20LKprEpLkXb7gXinJf4vvDdQe/BS8E4kL/dgE=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=

--- a/integration/deployment/backup_cleanup_test.go
+++ b/integration/deployment/backup_cleanup_test.go
@@ -12,11 +12,11 @@ import (
 	. "github.com/cloudfoundry-incubator/bosh-backup-and-restore/integration"
 	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/testcluster"
 
+	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/internal/cf-webmock/mockbosh"
+	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/internal/cf-webmock/mockhttp"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
-	"github.com/pivotal-cf-experimental/cf-webmock/mockbosh"
-	"github.com/pivotal-cf-experimental/cf-webmock/mockhttp"
 )
 
 var _ = Describe("Backup cleanup", func() {

--- a/integration/deployment/backup_test.go
+++ b/integration/deployment/backup_test.go
@@ -11,12 +11,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/internal/cf-webmock/mockbosh"
+	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/internal/cf-webmock/mockhttp"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
 	"github.com/onsi/gomega/gexec"
-	"github.com/pivotal-cf-experimental/cf-webmock/mockbosh"
-	"github.com/pivotal-cf-experimental/cf-webmock/mockhttp"
 
 	. "github.com/cloudfoundry-incubator/bosh-backup-and-restore/integration"
 	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/testcluster"

--- a/integration/deployment/cli_test.go
+++ b/integration/deployment/cli_test.go
@@ -6,12 +6,12 @@ import (
 
 	"fmt"
 
+	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/internal/cf-webmock/mockbosh"
+	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/internal/cf-webmock/mockhttp"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
 	"github.com/onsi/gomega/gexec"
-	"github.com/pivotal-cf-experimental/cf-webmock/mockbosh"
-	"github.com/pivotal-cf-experimental/cf-webmock/mockhttp"
 )
 
 var _ = Describe("CLI Interface", func() {

--- a/integration/deployment/pre_backup_check_test.go
+++ b/integration/deployment/pre_backup_check_test.go
@@ -8,8 +8,8 @@ import (
 	. "github.com/cloudfoundry-incubator/bosh-backup-and-restore/integration"
 	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/testcluster"
 
-	"github.com/pivotal-cf-experimental/cf-webmock/mockbosh"
-	"github.com/pivotal-cf-experimental/cf-webmock/mockhttp"
+	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/internal/cf-webmock/mockbosh"
+	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/internal/cf-webmock/mockhttp"
 
 	"github.com/onsi/gomega/gbytes"
 	"github.com/onsi/gomega/gexec"

--- a/integration/deployment/restore_cleanup_test.go
+++ b/integration/deployment/restore_cleanup_test.go
@@ -4,12 +4,12 @@ import (
 	"io/ioutil"
 	"os"
 
+	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/internal/cf-webmock/mockbosh"
+	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/internal/cf-webmock/mockhttp"
 	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/testcluster"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
-	"github.com/pivotal-cf-experimental/cf-webmock/mockbosh"
-	"github.com/pivotal-cf-experimental/cf-webmock/mockhttp"
 )
 
 var _ = Describe("Restore cleanup", func() {

--- a/integration/deployment/restore_test.go
+++ b/integration/deployment/restore_test.go
@@ -5,9 +5,9 @@ import (
 	"io/ioutil"
 	"os"
 
+	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/internal/cf-webmock/mockbosh"
+	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/internal/cf-webmock/mockhttp"
 	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/testcluster"
-	"github.com/pivotal-cf-experimental/cf-webmock/mockbosh"
-	"github.com/pivotal-cf-experimental/cf-webmock/mockhttp"
 
 	"archive/tar"
 	"bytes"

--- a/integration/deployment/web_mock_helpers.go
+++ b/integration/deployment/web_mock_helpers.go
@@ -5,9 +5,9 @@ import (
 	"math/rand"
 	"strings"
 
+	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/internal/cf-webmock/mockbosh"
+	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/internal/cf-webmock/mockhttp"
 	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/testcluster"
-	"github.com/pivotal-cf-experimental/cf-webmock/mockbosh"
-	"github.com/pivotal-cf-experimental/cf-webmock/mockhttp"
 )
 
 func MockDirectorWith(director *mockhttp.Server, info mockhttp.MockedResponseBuilder, vmsResponse []mockhttp.MockedResponseBuilder, manifestResponse []mockhttp.MockedResponseBuilder, sshResponse []mockhttp.MockedResponseBuilder, cleanupResponse []mockhttp.MockedResponseBuilder) {

--- a/integration/director/cli_test.go
+++ b/integration/director/cli_test.go
@@ -10,12 +10,12 @@ import (
 
 	"path/filepath"
 
+	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/internal/cf-webmock/mockbosh"
+	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/internal/cf-webmock/mockhttp"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
 	"github.com/onsi/gomega/gexec"
-	"github.com/pivotal-cf-experimental/cf-webmock/mockbosh"
-	"github.com/pivotal-cf-experimental/cf-webmock/mockhttp"
 )
 
 var _ = Describe("CLI Interface", func() {

--- a/internal/cf-webmock/README.md
+++ b/internal/cf-webmock/README.md
@@ -1,0 +1,4 @@
+The cf-webmock code was once hosted at https://github.com/pivotal-cf-experimental/cf-webmock
+But this was not maintained and was archived.
+So the relevant bits have been moved into this repo.
+The license of the original was Apache 2, which is the same as the license of this repo.

--- a/internal/cf-webmock/mockbosh/delete_deployment.go
+++ b/internal/cf-webmock/mockbosh/delete_deployment.go
@@ -1,0 +1,17 @@
+package mockbosh
+
+import "github.com/cloudfoundry-incubator/bosh-backup-and-restore/internal/cf-webmock/mockhttp"
+
+type deleteDeployMock struct {
+	*mockhttp.MockHttp
+}
+
+func DeleteDeployment(deploymentName string) *deleteDeployMock {
+	return &deleteDeployMock{
+		MockHttp: mockhttp.NewMockedHttpRequest("DELETE", "/deployments/"+deploymentName),
+	}
+}
+
+func (d *deleteDeployMock) RedirectsToTask(taskID int) *mockhttp.MockHttp {
+	return d.RedirectsTo(taskURL(taskID))
+}

--- a/internal/cf-webmock/mockbosh/deploy.go
+++ b/internal/cf-webmock/mockbosh/deploy.go
@@ -1,0 +1,39 @@
+package mockbosh
+
+import (
+	"gopkg.in/yaml.v2"
+
+	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/internal/cf-webmock/mockhttp"
+	. "github.com/onsi/gomega"
+)
+
+type deployMock struct {
+	expectedManifest []byte
+	*mockhttp.MockHttp
+}
+
+func Deploy() *deployMock {
+	mock := &deployMock{MockHttp: mockhttp.NewMockedHttpRequest("POST", "/deployments")}
+	mock.WithContentType("text/yaml")
+	return mock
+}
+
+func (d *deployMock) RedirectsToTask(taskID int) *mockhttp.MockHttp {
+	return d.RedirectsTo(taskURL(taskID))
+}
+
+func (d *deployMock) WithRawManifest(manifest []byte) *deployMock {
+	d.WithBody(string(manifest))
+	return d
+}
+
+func (d *deployMock) WithManifest(manifest interface{}) *deployMock {
+	d.WithBody(toYaml(manifest))
+	return d
+}
+
+func toYaml(obj interface{}) string {
+	data, err := yaml.Marshal(obj)
+	Expect(err).NotTo(HaveOccurred())
+	return string(data)
+}

--- a/internal/cf-webmock/mockbosh/errand.go
+++ b/internal/cf-webmock/mockbosh/errand.go
@@ -1,0 +1,21 @@
+package mockbosh
+
+import (
+	"fmt"
+
+	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/internal/cf-webmock/mockhttp"
+)
+
+type errandMock struct {
+	*mockhttp.MockHttp
+}
+
+func Errand(deploymentName, errandName string) *errandMock {
+	return &errandMock{
+		MockHttp: mockhttp.NewMockedHttpRequest("POST", fmt.Sprintf("/deployments/%s/errands/%s/runs", deploymentName, errandName)),
+	}
+}
+
+func (e *errandMock) RedirectsToTask(taskID int) *mockhttp.MockHttp {
+	return e.RedirectsTo(taskURL(taskID))
+}

--- a/internal/cf-webmock/mockbosh/get_deployments.go
+++ b/internal/cf-webmock/mockbosh/get_deployments.go
@@ -1,0 +1,28 @@
+package mockbosh
+
+import (
+	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/internal/cf-webmock/mockhttp"
+)
+
+type getDeploymentMock struct {
+	*mockhttp.MockHttp
+}
+
+type deployment struct {
+	Name string `json:"name"`
+}
+
+func GetDeployments() *getDeploymentMock {
+	return &getDeploymentMock{
+		MockHttp: mockhttp.NewMockedHttpRequest("GET", "/deployments"),
+	}
+}
+
+func (d *getDeploymentMock) RespondsWithListOfDeployments(deployments []string) *mockhttp.MockHttp {
+	var deps []deployment
+
+	for _, dep := range deployments {
+		deps = append(deps, deployment{Name: dep})
+	}
+	return d.RespondsWithJson(deps)
+}

--- a/internal/cf-webmock/mockbosh/info.go
+++ b/internal/cf-webmock/mockbosh/info.go
@@ -1,0 +1,27 @@
+package mockbosh
+
+import "github.com/cloudfoundry-incubator/bosh-backup-and-restore/internal/cf-webmock/mockhttp"
+
+type infoMock struct {
+	*mockhttp.MockHttp
+}
+
+func Info() *infoMock {
+	return &infoMock{
+		MockHttp: mockhttp.NewMockedHttpRequest("GET", "/info").SkipAuthentication(),
+	}
+}
+
+func (m *infoMock) RespondsWithSufficientAPIVersion() *mockhttp.MockHttp {
+	return m.RespondsWith(`{"version":"1.3262.0.0 (00000000)"}`)
+}
+
+func (m *infoMock) WithAuthTypeBasic() *mockhttp.MockHttp {
+	return m.RespondsWithJson(map[string]interface{}{"user_authentication": map[string]string{"type": "basic"}})
+}
+
+func (m *infoMock) WithAuthTypeUAA(url string) *mockhttp.MockHttp {
+	return m.RespondsWithJson(map[string]interface{}{"user_authentication": map[string]interface{}{
+		"type": "uaa", "options": map[string]string{"url": url},
+	}})
+}

--- a/internal/cf-webmock/mockbosh/manifest.go
+++ b/internal/cf-webmock/mockbosh/manifest.go
@@ -1,0 +1,33 @@
+package mockbosh
+
+import (
+	"fmt"
+
+	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/internal/cf-webmock/mockhttp"
+	. "github.com/onsi/gomega"
+	"gopkg.in/yaml.v2"
+)
+
+type manifestMock struct {
+	*mockhttp.MockHttp
+}
+
+func GetDeployment(deploymentName string) *manifestMock {
+	mock := &manifestMock{MockHttp: mockhttp.NewMockedHttpRequest("GET", fmt.Sprintf("/deployments/%s", deploymentName))}
+	return mock
+}
+
+func Manifest(deploymentName string) *manifestMock {
+	return GetDeployment(deploymentName)
+}
+
+func (t *manifestMock) RespondsWith(manifest []byte) *mockhttp.MockHttp {
+	data := map[string]string{"manifest": string(manifest)}
+	return t.RespondsWithJson(data)
+}
+
+func (t *manifestMock) RespondsWithManifest(manifest interface{}) *mockhttp.MockHttp {
+	data, err := yaml.Marshal(manifest)
+	Expect(err).NotTo(HaveOccurred())
+	return t.RespondsWith(data)
+}

--- a/internal/cf-webmock/mockbosh/mockbosh.go
+++ b/internal/cf-webmock/mockbosh/mockbosh.go
@@ -1,0 +1,29 @@
+package mockbosh
+
+import (
+	"crypto/tls"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/internal/cf-webmock/mockhttp"
+)
+
+func New() *mockhttp.Server {
+	return mockhttp.StartServer("mock-bosh", httptest.NewServer)
+}
+
+func NewTLS() *mockhttp.Server {
+	return mockhttp.StartServer("mock-bosh", httptest.NewTLSServer)
+}
+
+func NewTLSWithCert(cert tls.Certificate) *mockhttp.Server {
+	return mockhttp.StartServer("mock-bosh", func(handler http.Handler) *httptest.Server {
+		ts := httptest.NewUnstartedServer(handler)
+
+		ts.TLS = &tls.Config{
+			Certificates: []tls.Certificate{cert},
+		}
+		ts.StartTLS()
+		return ts
+	})
+}

--- a/internal/cf-webmock/mockbosh/ssh.go
+++ b/internal/cf-webmock/mockbosh/ssh.go
@@ -1,0 +1,53 @@
+package mockbosh
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/internal/cf-webmock/mockhttp"
+	. "github.com/onsi/gomega"
+)
+
+type sshMock struct {
+	*mockhttp.MockHttp
+	instanceGroup string
+	callback      func(string, string)
+}
+
+func StartSSHSession(deploymentName string) *sshMock {
+	mock := &sshMock{
+		MockHttp: mockhttp.NewMockedHttpRequest("POST", fmt.Sprintf("/deployments/%s/ssh", deploymentName)),
+	}
+	mock.SetResponseCallback(mock.verifyRequest)
+	return mock
+}
+
+var CleanupSSHSession = StartSSHSession
+
+func (mock *sshMock) RedirectsToTask(taskID int) *mockhttp.MockHttp {
+	return mock.RedirectsTo(taskURL(taskID))
+}
+
+func (mock *sshMock) ForInstanceGroup(instanceGroup string) *sshMock {
+	mock.instanceGroup = instanceGroup
+	return mock
+}
+func (mock *sshMock) SetSSHResponseCallback(callback func(string, string)) *sshMock {
+	mock.callback = callback
+	return mock
+}
+
+func (mock *sshMock) verifyRequest(body []byte) {
+	response := map[string]interface{}{}
+	Expect(json.Unmarshal(body, &response)).To(Succeed())
+	params := response["params"].(map[string]interface{})
+	target := response["target"].(map[string]interface{})
+
+	if mock.instanceGroup != "" {
+		Expect(target["job"]).To(Equal(mock.instanceGroup))
+	}
+
+	if mock.callback != nil {
+		mock.callback(params["user"].(string), params["public_key"].(string))
+	}
+}

--- a/internal/cf-webmock/mockbosh/task.go
+++ b/internal/cf-webmock/mockbosh/task.go
@@ -1,0 +1,33 @@
+package mockbosh
+
+import (
+	"fmt"
+
+	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/internal/cf-webmock/mockhttp"
+)
+
+const (
+	TaskQueued     = "queued"
+	TaskProcessing = "processing"
+	TaskDone       = "done"
+	TaskError      = "error"
+)
+
+type taskMock struct {
+	*mockhttp.MockHttp
+	taskID int
+}
+
+func Task(taskID int) *taskMock {
+	return &taskMock{
+		MockHttp: mockhttp.NewMockedHttpRequest("GET", fmt.Sprintf("/tasks/%d", taskID)),
+		taskID:   taskID,
+	}
+}
+
+func (t *taskMock) RespondsWithTaskContainingState(provisioningTaskState string) *mockhttp.MockHttp {
+	return t.RespondsWithJson(map[string]interface{}{
+		"id":    t.taskID,
+		"state": provisioningTaskState,
+	})
+}

--- a/internal/cf-webmock/mockbosh/task_output.go
+++ b/internal/cf-webmock/mockbosh/task_output.go
@@ -1,0 +1,70 @@
+package mockbosh
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"reflect"
+
+	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/internal/cf-webmock/mockhttp"
+	. "github.com/onsi/gomega"
+)
+
+type VMsOutput struct {
+	IPs       []string
+	JobName   string `json:"job_name"`
+	Index     *int   `json:"index"`
+	ID        string `json:"id"`
+	Bootstrap bool   `json:"bootstrap"`
+}
+
+type taskOutputMock struct {
+	*mockhttp.MockHttp
+}
+
+func TaskEvent(taskId int) *taskOutputMock {
+	mock := &taskOutputMock{MockHttp: mockhttp.NewMockedHttpRequest("GET", fmt.Sprintf("/tasks/%d/output?type=event", taskId))}
+	return mock
+}
+
+func TaskOutput(taskId int) *taskOutputMock {
+	mock := &taskOutputMock{MockHttp: mockhttp.NewMockedHttpRequest("GET", fmt.Sprintf("/tasks/%d/output?type=result", taskId))}
+	return mock
+}
+
+func (t *taskOutputMock) RespondsWithVMsOutput(vms interface{}) *mockhttp.MockHttp {
+	output := bytes.NewBuffer([]byte{})
+	encoder := json.NewEncoder(output)
+
+	for _, line := range interfaceSlice(vms) {
+		Expect(encoder.Encode(line)).ToNot(HaveOccurred())
+	}
+
+	return t.RespondsWith(string(output.Bytes()))
+}
+
+func (t *taskOutputMock) RespondsWithTaskOutput(taskOutput interface{}) *mockhttp.MockHttp {
+	output := bytes.NewBuffer([]byte{})
+	encoder := json.NewEncoder(output)
+
+	for _, line := range interfaceSlice(taskOutput) {
+		Expect(encoder.Encode(line)).ToNot(HaveOccurred())
+	}
+
+	return t.RespondsWith(string(output.Bytes()))
+}
+
+func interfaceSlice(slice interface{}) []interface{} {
+	s := reflect.ValueOf(slice)
+	if s.Kind() != reflect.Slice {
+		panic("needs to be called with a slice type")
+	}
+
+	ret := make([]interface{}, s.Len())
+
+	for i := 0; i < s.Len(); i++ {
+		ret[i] = s.Index(i).Interface()
+	}
+
+	return ret
+}

--- a/internal/cf-webmock/mockbosh/tasks.go
+++ b/internal/cf-webmock/mockbosh/tasks.go
@@ -1,0 +1,37 @@
+package mockbosh
+
+import (
+	"fmt"
+
+	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/internal/cf-webmock/mockhttp"
+)
+
+type tasksMock struct {
+	*mockhttp.MockHttp
+}
+
+func Tasks(deploymentName string) *tasksMock {
+	mock := &tasksMock{MockHttp: mockhttp.NewMockedHttpRequest("GET", fmt.Sprintf("/tasks?deployment=%s", deploymentName))}
+	return mock
+}
+
+func (t *tasksMock) RespondsWithNoTasks() *mockhttp.MockHttp {
+	return t.RespondsWithJson([]interface{}{})
+}
+
+func (t *tasksMock) RespondsWithATaskContainingState(provisioningTaskState string, description string) *mockhttp.MockHttp {
+	return t.RespondsWithJson([]interface{}{
+		map[string]string{
+			"state":       provisioningTaskState,
+			"description": description,
+		},
+	})
+}
+
+func (t *tasksMock) RespondsWithATask(task interface{}) *mockhttp.MockHttp {
+	return t.RespondsWithJson([]interface{}{task})
+}
+
+func taskURL(taskID int) string {
+	return fmt.Sprintf("/tasks/%d", taskID)
+}

--- a/internal/cf-webmock/mockbosh/vms.go
+++ b/internal/cf-webmock/mockbosh/vms.go
@@ -1,0 +1,24 @@
+package mockbosh
+
+import (
+	"fmt"
+
+	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/internal/cf-webmock/mockhttp"
+)
+
+type vmsForDeploymentMock struct {
+	*mockhttp.MockHttp
+	deploymentName string
+}
+
+func VMsForDeployment(deploymentName string) *vmsForDeploymentMock {
+	mock := &vmsForDeploymentMock{
+		MockHttp:       mockhttp.NewMockedHttpRequest("GET", fmt.Sprintf("/deployments/%s/vms?format=full", deploymentName)),
+		deploymentName: deploymentName,
+	}
+	return mock
+}
+
+func (t *vmsForDeploymentMock) RedirectsToTask(taskID int) *mockhttp.MockHttp {
+	return t.RedirectsTo(taskURL(taskID))
+}

--- a/internal/cf-webmock/mockhttp/http_mock.go
+++ b/internal/cf-webmock/mockhttp/http_mock.go
@@ -1,0 +1,149 @@
+package mockhttp
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"strings"
+
+	. "github.com/onsi/gomega"
+)
+
+type MockHttp struct {
+	expectedMethod              string
+	expectedUrl                 string
+	expectedContentType         string
+	expectedBody                string
+	expectedAuthorizationHeader string
+	expectedFormValues          map[string]string
+
+	responseRedirectToUrl string
+	responseStatus        int
+	responseBody          string
+
+	responseCallback func(rawbody []byte)
+
+	authenticated bool
+}
+
+func (i *MockHttp) Fails(message string) *MockHttp {
+	i.responseBody = message
+	i.responseStatus = http.StatusInternalServerError
+	return i
+}
+
+func (i *MockHttp) RedirectsTo(uri string) *MockHttp {
+	i.responseStatus = http.StatusFound
+	i.responseRedirectToUrl = uri
+	return i
+}
+func (i *MockHttp) NotFound() *MockHttp {
+	i.responseBody = ""
+	i.responseStatus = http.StatusNotFound
+	return i
+}
+func (i *MockHttp) RespondsWithUnauthorized(body string) *MockHttp {
+	i.responseBody = body
+	i.responseStatus = http.StatusUnauthorized
+	return i
+}
+
+func (i *MockHttp) RespondsWithJson(obj interface{}) *MockHttp {
+	data, err := json.Marshal(obj)
+	Expect(err).NotTo(HaveOccurred())
+	i.RespondsWith(string(data))
+	return i
+}
+
+func (i *MockHttp) RespondsWith(body string) *MockHttp {
+	i.responseStatus = http.StatusOK
+	i.responseBody = body
+	return i
+}
+
+func (i *MockHttp) SkipAuthentication() *MockHttp {
+	i.authenticated = false
+	return i
+}
+func (i *MockHttp) RespondsEmpty() *MockHttp {
+	i.responseBody = ""
+	i.responseStatus = http.StatusNoContent
+	return i
+}
+
+func (i *MockHttp) WithContentType(contentType string) *MockHttp {
+	i.expectedContentType = contentType
+	return i
+}
+
+func (i *MockHttp) WithBody(body string) *MockHttp {
+	i.expectedBody = body
+	return i
+}
+
+func (i *MockHttp) WithAuthorizationHeader(auth string) *MockHttp {
+	i.expectedAuthorizationHeader = auth
+	return i
+}
+
+func NewMockedHttpRequest(method, url string) *MockHttp {
+	return &MockHttp{expectedMethod: method, expectedUrl: url, authenticated: true}
+}
+
+func (i *MockHttp) Verify(req *http.Request, d *Server) {
+	Expect(req.Method+" "+req.URL.String()).To(Equal(i.expectedMethod+" "+i.expectedUrl), fmt.Sprintf("Received:\n\t%s\nCompleted mocks:\n%s\nPending mocks:\n%s\n", req.Method+" "+req.URL.String(), strings.Join(d.completedMocks(), "\n"), strings.Join(d.pendingMocks(), "\n")))
+	if i.authenticated {
+		if d.expectedAuthorizationHeader != "" {
+			Expect(req.Header.Get("Authorization")).To(Equal(d.expectedAuthorizationHeader))
+		}
+		if i.expectedAuthorizationHeader != "" {
+			Expect(req.Header.Get("Authorization")).To(Equal(i.expectedAuthorizationHeader))
+		}
+	}
+
+	if i.expectedContentType != "" {
+		Expect(req.Header.Get("Content-Type")).To(Equal(i.expectedContentType))
+	}
+
+	rawBody, err := ioutil.ReadAll(req.Body)
+	Expect(err).NotTo(HaveOccurred())
+
+	if i.expectedBody != "" {
+		Expect(string(rawBody)).To(Equal(i.expectedBody))
+	}
+	if i.responseCallback != nil {
+		i.responseCallback(rawBody)
+	}
+	if i.expectedFormValues != nil {
+		for key, value := range i.expectedFormValues {
+			Expect(req.FormValue(key)).To(Equal(value))
+		}
+	}
+
+	Expect(req.Method+" "+req.URL.String()).To(Equal(i.expectedMethod+" "+i.expectedUrl), fmt.Sprintf("Received:\n\t%s\nCompleted mocks:\n%s\nPending mocks:\n%s\n", req.Method+" "+req.URL.String(), strings.Join(d.completedMocks(), "\n"), strings.Join(d.pendingMocks(), "\n")))
+}
+
+func (i *MockHttp) Respond(writer http.ResponseWriter, logger *log.Logger) {
+	if len(i.responseRedirectToUrl) != 0 {
+		logger.Printf("Redirecting to %s\n", i.responseRedirectToUrl)
+		writer.Header().Set("Location", i.responseRedirectToUrl)
+	}
+	logger.Printf("Reponding with code(%d)\n%s\n", i.responseStatus, i.responseBody)
+	writer.WriteHeader(i.responseStatus)
+	io.WriteString(writer, i.responseBody)
+}
+
+func (i *MockHttp) For(comment string) *MockHttp {
+	return i
+}
+
+func (i *MockHttp) Url() string {
+	return i.expectedMethod + " " + i.expectedUrl
+}
+
+func (i *MockHttp) SetResponseCallback(b func(rawbody []byte)) {
+	i.responseCallback = b
+}

--- a/internal/cf-webmock/mockhttp/server.go
+++ b/internal/cf-webmock/mockhttp/server.go
@@ -1,0 +1,98 @@
+package mockhttp
+
+import (
+	"encoding/base64"
+	"fmt"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"runtime/debug"
+	"strings"
+	"sync"
+
+	. "github.com/onsi/ginkgo"
+)
+
+type Server struct {
+	expectedAuthorizationHeader string
+
+	*httptest.Server
+	*sync.Mutex
+
+	mockHandlers   []MockedResponseBuilder
+	currentHandler int
+
+	logger *log.Logger
+}
+
+func StartServer(name string, startTestServer func(http.Handler) *httptest.Server) *Server {
+	d := &Server{Mutex: new(sync.Mutex)}
+	d.Server = startTestServer(d)
+
+	d.logger = log.New(GinkgoWriter, "["+name+"] ", log.LstdFlags)
+	return d
+}
+
+func (d *Server) ExpectedAuthorizationHeader(header string) {
+	d.expectedAuthorizationHeader = header
+}
+func (d *Server) ExpectedBasicAuth(username, password string) {
+	d.ExpectedAuthorizationHeader(basicAuth(username, password))
+}
+
+func (d *Server) ServeHTTP(writer http.ResponseWriter, req *http.Request) {
+	d.Lock()
+	defer d.Unlock()
+	defer GinkgoRecover()
+	if d.currentHandler >= len(d.mockHandlers) {
+		Fail(fmt.Sprintf("unmocked call received\n\t%s\nCompleted mocks:\n%s\nPending mocks:\n%s\n", req.Method+" "+req.URL.String(), strings.Join(d.completedMocks(), "\n"), strings.Join(d.pendingMocks(), "\n")))
+	}
+
+	d.logger.Printf("%s %s\n", req.Method, req.URL.String())
+	d.mockHandlers[d.currentHandler].Verify(req, d)
+	d.mockHandlers[d.currentHandler].Respond(writer, d.logger)
+	d.currentHandler += 1
+}
+
+func (d *Server) completedMocks() []string {
+	completedMocks := []string{}
+	for i := 0; i < d.currentHandler; i++ {
+		completedMocks = append(completedMocks, "\t"+d.mockHandlers[i].Url())
+	}
+	return completedMocks
+}
+
+func (d *Server) pendingMocks() []string {
+	pendingMocks := []string{}
+	for i := d.currentHandler; i < len(d.mockHandlers); i++ {
+		pendingMocks = append(pendingMocks, "\t"+d.mockHandlers[i].Url())
+	}
+	return pendingMocks
+}
+
+func (d *Server) VerifyAndMock(mockedResponses ...MockedResponseBuilder) {
+	d.Lock()
+	defer d.Unlock()
+	d.VerifyMocks()
+
+	d.currentHandler = 0
+	d.mockHandlers = mockedResponses
+}
+
+func (d *Server) VerifyMocks() {
+	if len(d.mockHandlers) != d.currentHandler {
+		debug.PrintStack()
+		Fail(fmt.Sprintf("Uninvoked mocks\nCompleted mocks:\n%s\nPending mocks:\n%s\n", strings.Join(d.completedMocks(), "\n"), strings.Join(d.pendingMocks(), "\n")))
+	}
+}
+
+type MockedResponseBuilder interface {
+	Verify(req *http.Request, d *Server)
+	Respond(writer http.ResponseWriter, logger *log.Logger)
+	Url() string
+}
+
+func basicAuth(username, password string) string {
+	auth := username + ":" + password
+	return "Basic " + base64.StdEncoding.EncodeToString([]byte(auth))
+}

--- a/internal/cf-webmock/mockuaa/mockuaa.go
+++ b/internal/cf-webmock/mockuaa/mockuaa.go
@@ -1,0 +1,196 @@
+package mockuaa
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+
+	. "github.com/onsi/gomega"
+)
+
+const (
+	UnauthorizedError            = "you are unauthorized"
+	UnauthorizedErrorDescription = "please go away"
+	MalformedResponseUser        = "MalformedResponse"
+	InternalServerErrorUser      = "InternalServerError"
+	InternalServerErrorMessage   = "Shut the F up, Donny"
+)
+
+type ClientCredentialsServer struct {
+	*httptest.Server
+
+	UAAClientID     string
+	UAAClientSecret string
+	TokenToReturn   string
+
+	ValiditySecondsToReturn int
+	TokensIssued            int
+}
+
+type UserCredentialsServer struct {
+	*httptest.Server
+
+	ClientID      string
+	ClientSecret  string
+	Username      string
+	Password      string
+	TokenToReturn string
+
+	ValiditySecondsToReturn int
+	TokensIssued            int
+}
+
+func (s ClientCredentialsServer) ExpectedAuthorizationHeader() string {
+	return "Bearer " + s.TokenToReturn
+}
+
+func (s *ClientCredentialsServer) ServeHTTP(writer http.ResponseWriter, req *http.Request) {
+	validateRequest(req, "")
+
+	username, password, ok := req.BasicAuth()
+	Expect(ok).To(BeTrue())
+
+	// Default validity seconds = 599
+	if s.ValiditySecondsToReturn == 0 {
+		s.ValiditySecondsToReturn = 599
+	}
+
+	var status int
+	var response map[string]interface{}
+
+	if username == MalformedResponseUser {
+		status, response = handleMalformedResponse(s.ValiditySecondsToReturn)
+	} else if username == InternalServerErrorUser {
+		handleInternalServerError(writer)
+		return
+	} else if (username == s.UAAClientID) && (password == s.UAAClientSecret) {
+		status, response = handleAuthorised(s.TokenToReturn, s.ValiditySecondsToReturn)
+		s.TokensIssued++
+	} else {
+		status, response = handleUnauthorised()
+	}
+
+	writeStatusAndResponse(status, response, writer)
+}
+
+func (s *UserCredentialsServer) ServeHTTP(writer http.ResponseWriter, req *http.Request) {
+	validateRequest(req, "password")
+
+	clientID, clientSecret, ok := req.BasicAuth()
+	Expect(ok).To(BeTrue())
+	username := req.PostFormValue("username")
+	password := req.PostFormValue("password")
+
+	// Default validity seconds = 599
+	if s.ValiditySecondsToReturn == 0 {
+		s.ValiditySecondsToReturn = 599
+	}
+
+	var status int
+	var response map[string]interface{}
+
+	if username == MalformedResponseUser {
+		status, response = handleMalformedResponse(s.ValiditySecondsToReturn)
+	} else if username == InternalServerErrorUser {
+		handleInternalServerError(writer)
+		return
+	} else if (clientID == s.ClientID) && (clientSecret == s.ClientSecret) && (username == s.Username) && (password == s.Password) {
+		status, response = handleAuthorised(s.TokenToReturn, s.ValiditySecondsToReturn)
+		s.TokensIssued++
+	} else {
+		status, response = handleUnauthorised()
+	}
+
+	writeStatusAndResponse(status, response, writer)
+}
+
+func writeStatusAndResponse(status int, response map[string]interface{}, writer http.ResponseWriter) {
+	writer.Header().Set("Content-Type", "application/json; charset=UTF-8")
+	writer.WriteHeader(status)
+	err := json.NewEncoder(writer).Encode(response)
+	Expect(err).NotTo(HaveOccurred())
+}
+
+func validateRequest(req *http.Request, grantType string) {
+	Expect(req.Method).To(Equal(http.MethodPost))
+	Expect(req.URL.Path).To(Equal("/oauth/token"))
+	Expect(req.URL.Query().Get("grant_type")).To(Equal(grantType))
+}
+
+func handleMalformedResponse(validitySecondsToReturn int) (int, map[string]interface{}) {
+	status := http.StatusOK
+	response := map[string]interface{}{
+		// "access_token": missing!
+		"token_type": "bearer",
+		"expires_in": validitySecondsToReturn,
+		"scope":      "bosh.admin",
+		"jti":        "some-random-uuid",
+	}
+	return status, response
+}
+
+func handleInternalServerError(writer http.ResponseWriter) {
+	status := http.StatusInternalServerError
+	writer.Header().Set("Content-Type", "text/plain; charset=UTF-8")
+	writer.WriteHeader(status)
+	writer.Write([]byte(InternalServerErrorMessage))
+}
+
+func handleAuthorised(tokenToReturn string, validitySecondsToReturn int) (int, map[string]interface{}) {
+	status := http.StatusOK
+	response := map[string]interface{}{
+		"access_token": tokenToReturn,
+		"token_type":   "bearer",
+		"expires_in":   validitySecondsToReturn,
+		"scope":        "bosh.admin",
+		"jti":          "some-random-uuid",
+	}
+	return status, response
+}
+
+func handleUnauthorised() (int, map[string]interface{}) {
+	status := http.StatusUnauthorized
+	response := map[string]interface{}{
+		"error":             UnauthorizedError,
+		"error_description": UnauthorizedErrorDescription,
+	}
+	return status, response
+}
+
+func NewClientCredentialsServer(uaaClientID, uaaClientSecret, tokenToReturn string) *ClientCredentialsServer {
+	return startClientCredentialsServer(uaaClientID, uaaClientSecret, tokenToReturn, httptest.NewServer)
+}
+
+func NewClientCredentialsServerTLS(uaaClientID, uaaClientSecret, tokenToReturn string) *ClientCredentialsServer {
+	return startClientCredentialsServer(uaaClientID, uaaClientSecret, tokenToReturn, httptest.NewTLSServer)
+}
+
+func NewUserCredentialsServer(clientID, clientSecret, username, password, tokenToReturn string) *UserCredentialsServer {
+	return startUserCredentialsServer(clientID, clientSecret, username, password, tokenToReturn, httptest.NewServer)
+}
+
+func NewUserCredentialsServerTLS(clientID, clientSecret, username, password, tokenToReturn string) *UserCredentialsServer {
+	return startUserCredentialsServer(clientID, clientSecret, username, password, tokenToReturn, httptest.NewTLSServer)
+}
+
+func startClientCredentialsServer(uaaClientID, uaaClientSecret, tokenToReturn string, serverStarter func(http.Handler) *httptest.Server) *ClientCredentialsServer {
+	uaa := &ClientCredentialsServer{
+		UAAClientID:     uaaClientID,
+		UAAClientSecret: uaaClientSecret,
+		TokenToReturn:   tokenToReturn,
+	}
+	uaa.Server = serverStarter(uaa)
+	return uaa
+}
+
+func startUserCredentialsServer(clientID, clientSecret, username, password, tokenToReturn string, serverStarter func(http.Handler) *httptest.Server) *UserCredentialsServer {
+	uaa := &UserCredentialsServer{
+		ClientID:      clientID,
+		ClientSecret:  clientSecret,
+		Username:      username,
+		Password:      password,
+		TokenToReturn: tokenToReturn,
+	}
+	uaa.Server = serverStarter(uaa)
+	return uaa
+}


### PR DESCRIPTION
cf-webmock from https://github.com/pivotal-cf-experimental/cf-webmock is no longer maintained, and the repo has been archived. It has therefore been incorporated into this repo, so that we can keep it up to date (updating to Ginkgo V2 being the thing we want to do next). There are no licensing concerns as both this project and cf-webmocks have Apache 2.0 licenses and were largely contributed by VMware.