### PR TITLE
Make sure BBR can be installed in M1 devices

### DIFF
--- a/ci/tasks/bbr-update-homebrew-formula/task.sh
+++ b/ci/tasks/bbr-update-homebrew-formula/task.sh
@@ -1,23 +1,53 @@
 #!/usr/bin/env bash
 
+[ -z "$DEBUG" ] || set -x
+
 set -eu
 set -o pipefail
 
+[ -d bbr-release/ ]
+[ -d homebrew-tap/ ]
+
 VERSION="$(cat "bbr-release/version")"
-SHA256="$(shasum -a 256 "bbr-release/bbr-${VERSION}.tar" | cut -d ' ' -f 1)"
+
+SHA256_OSX_AMD64="$(echo -n "$(cat bbr-release/bbr-"${VERSION}"-darwin-amd64.sha256)")"
+SHA256_OSX_ARM64="$(echo -n "$(cat bbr-release/bbr-"${VERSION}"-darwin-arm64.sha256)")"
+SHA256_LINUX_AMD64="$(echo -n "$(cat bbr-release/bbr-"${VERSION}"-linux-amd64.sha256)")"
 
 pushd homebrew-tap
   cat <<EOF > bbr.rb
+#
+# This code has been generated automatically. Any changes will be overwritten.
+#
 class Bbr < Formula
   desc "BOSH Backup and Restore CLI"
-  homepage "https://github.com/cloudfoundry-incubator/bosh-backup-and-restore"
-  url "https://github.com/cloudfoundry-incubator/bosh-backup-and-restore/releases/download/v${VERSION}/bbr-${VERSION}.tar"
-  sha256 "${SHA256}"
+  homepage "https://github.com/cloudfoundry/bosh-backup-and-restore"
 
-  depends_on :arch => :x86_64
+  if OS.mac?
+    if Hardware::CPU.arm?
+      url "https://github.com/cloudfoundry/bosh-backup-and-restore/releases/download/v${VERSION}/bbr-${VERSION}-darwin-arm64"
+      sha256 "${SHA256_OSX_ARM64}"
+    else
+      url "https://github.com/cloudfoundry/bosh-backup-and-restore/releases/download/v${VERSION}/bbr-${VERSION}-darwin-amd64"
+      sha256 "${SHA256_OSX_AMD64}"
+    end
+  elsif OS.linux?
+    url "https://github.com/cloudfoundry/bosh-backup-and-restore/releases/download/v${VERSION}/bbr-${VERSION}-linux-amd64"
+    sha256 "${SHA256_LINUX_AMD64}"
+  end
 
   def install
-    bin.install "bbr-mac" => "bbr"
+    binary_name = "bbr"
+
+    if OS.mac?
+      if Hardware::CPU.arm?
+        bin.install "bbr-${VERSION}-darwin-arm64" => binary_name
+      else
+        bin.install "bbr-${VERSION}-darwin-amd64" => binary_name
+      end
+    elsif OS.linux?
+      bin.install "bbr-${VERSION}-linux-amd64" => binary_name
+    end
   end
 
   test do


### PR DESCRIPTION
Make it possible to install the BBR CLI on a MacOS device powered by Apple's M1 via Homebrew.

[#186079257]