### PR TITLE
modernize images

### DIFF
--- a/ci/images/backup-and-restore-minimal/Dockerfile
+++ b/ci/images/backup-and-restore-minimal/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.21.6 as go-binary
 
-FROM ubuntu:bionic
+FROM ubuntu:jammy
 
 ENV cf_cli_version 7.3.0
 ENV bosh_cli_version 7.2.3

--- a/ci/images/backup-and-restore/Dockerfile
+++ b/ci/images/backup-and-restore/Dockerfile
@@ -19,20 +19,30 @@ ARG TERRAFORM_VERSION
 RUN apt-get update && apt-get install -y \
   apt-transport-https \
   awscli \
+  autoconf \
+  patch \
+  build-essential \
+  rustc \
+  libyaml-dev \
+  libreadline6-dev \
   libreadline-dev \
+  libffi-dev \
   zlib1g-dev \
+  libncurses5-dev \
+  libgdbm5 \
+  libgdbm-dev \
+  libdb-dev \
+  libssl-dev \
+  uuid-dev \
   default-mysql-client \
   dnsutils \
   file \
-  libssl-dev \
   lsb-release \
   netcat-openbsd \
   openjdk-8-jdk \
   ruby-dev \
-  wbritish \
   ca-certificates \
   gettext-base \
-  libffi-dev \
   && rm -rf /var/lib/apt/lists/*
 
 # Install azure cli

--- a/ci/images/backup-and-restore/Dockerfile
+++ b/ci/images/backup-and-restore/Dockerfile
@@ -32,6 +32,7 @@ RUN apt-get update && apt-get install -y \
   wbritish \
   ca-certificates \
   gettext-base \
+  libffi-dev \
   && rm -rf /var/lib/apt/lists/*
 
 # Install azure cli
@@ -52,10 +53,10 @@ RUN apt-get update && apt-get install -y \
 # INSTALL RUBY
 #
 ENV RBENV_ROOT /home/vcap/.rbenv
-RUN git clone https://github.com/sstephenson/rbenv.git ${RBENV_ROOT}
+RUN git clone https://github.com/rbenv/rbenv.git ${RBENV_ROOT}
 
 RUN mkdir -p ${RBENV_ROOT}/plugins
-RUN git clone https://github.com/sstephenson/ruby-build.git ${RBENV_ROOT}/plugins/ruby-build
+RUN git clone https://github.com/rbenv/ruby-build.git ${RBENV_ROOT}/plugins/ruby-build
 RUN git clone https://github.com/rbenv/rbenv-each.git ${RBENV_ROOT}/plugins/rbenv-each
 
 ENV PATH ${RBENV_ROOT}/bin:${RBENV_ROOT}/shims:$PATH


### PR DESCRIPTION
- update minimal to be jammy based

- update backup-and-restore to not use rbenv from `sstephenson` but rather the real repos (it's forwarding now, but who knows what it will do in the future
- update apt packages to include the libraries specified in ruby-build docs