### PR TITLE
all bumpers should be serial

### DIFF
--- a/ci/pipelines/bbr-cli/pipeline.yml
+++ b/ci/pipelines/bbr-cli/pipeline.yml
@@ -1146,6 +1146,7 @@ jobs:
       resource: additional-environment
 
 - name: bump-golang
+  serial: true
   plan:
   - in_parallel:
     - get: cryogenics-concourse-tasks
@@ -1203,6 +1204,7 @@ jobs:
         source-repo: bosh-backup-and-restore-write-branch
 
 - name: bump-go-module
+  serial: true
   plan:
   - in_parallel:
     - get: cryogenics-concourse-tasks
@@ -1250,6 +1252,7 @@ jobs:
               source-repo: bosh-backup-and-restore-write-branch
 
 - name: bump-ci-tasks
+  serial: true
   plan:
   - in_parallel:
     - get: cryogenics-essentials


### PR DESCRIPTION
[#187071309]
they currently force push. That created issues when the same job got triggered twice ( for unknown reasons ) and job n-1 "overtook" job n ( n used a newer HEAD ) and force pushed over the changes made by n.