### PR TITLE
Added ssh connection rate limiting feature

### DIFF
--- a/bosh/build_client.go
+++ b/bosh/build_client.go
@@ -2,6 +2,7 @@ package bosh
 
 import (
 	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/instance"
+	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/ratelimiter"
 	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/ssh"
 	"github.com/cloudfoundry/bosh-cli/v7/director"
 	"github.com/pkg/errors"
@@ -10,7 +11,7 @@ import (
 	boshlog "github.com/cloudfoundry/bosh-utils/logger"
 )
 
-func BuildClient(targetUrl, username, password, caCert, bbrVersion string, logger boshlog.Logger) (Client, error) {
+func BuildClient(targetUrl, username, password, caCert, bbrVersion string, rateLimiter ratelimiter.RateLimiter, logger boshlog.Logger) (Client, error) {
 	var client Client
 
 	factoryConfig, err := director.NewConfigFromURL(targetUrl)
@@ -44,7 +45,7 @@ func BuildClient(targetUrl, username, password, caCert, bbrVersion string, logge
 		return client, errors.Wrap(err, "error building bosh director client")
 	}
 
-	return NewClient(boshDirector, director.NewSSHOpts, ssh.NewSshRemoteRunner, logger, instance.NewJobFinder(bbrVersion, logger), NewBoshManifestQuerier), nil
+	return NewClient(boshDirector, director.NewSSHOpts, ssh.NewSshRemoteRunner, rateLimiter, logger, instance.NewJobFinder(bbrVersion, logger), NewBoshManifestQuerier), nil
 }
 
 func getDirectorInfo(directorFactory director.Factory, factoryConfig director.FactoryConfig) (director.Info, error) {

--- a/bosh/build_client_test.go
+++ b/bosh/build_client_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/internal/cf-webmock/mockbosh"
 	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/internal/cf-webmock/mockhttp"
 	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/internal/cf-webmock/mockuaa"
+	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/ratelimiter"
 	boshlog "github.com/cloudfoundry/bosh-utils/logger"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -50,7 +51,7 @@ var _ = Describe("BuildClient", func() {
 				mockbosh.Manifest(deploymentName).RespondsWith([]byte("manifest contents")),
 			)
 
-			client, err := BuildClient(director.URL, username, password, caCert, bbrVersion, logger)
+			client, err := BuildClient(director.URL, username, password, caCert, bbrVersion, ratelimiter.NoOpRateLimiter{}, logger)
 
 			Expect(err).NotTo(HaveOccurred())
 			manifest, err := client.GetManifest(deploymentName)
@@ -75,7 +76,7 @@ var _ = Describe("BuildClient", func() {
 				mockbosh.Manifest(deploymentName).RespondsWith([]byte("manifest contents")),
 			)
 
-			client, err := BuildClient(director.URL, username, password, caCert, bbrVersion, logger)
+			client, err := BuildClient(director.URL, username, password, caCert, bbrVersion, ratelimiter.NoOpRateLimiter{}, logger)
 
 			Expect(err).NotTo(HaveOccurred())
 			manifest, err := client.GetManifest(deploymentName)
@@ -90,7 +91,7 @@ var _ = Describe("BuildClient", func() {
 			director.VerifyAndMock(
 				mockbosh.Info().WithAuthTypeUAA(""),
 			)
-			_, err := BuildClient(director.URL, username, password, caCert, bbrVersion, logger)
+			_, err := BuildClient(director.URL, username, password, caCert, bbrVersion, ratelimiter.NoOpRateLimiter{}, logger)
 
 			Expect(err).To(MatchError(ContainSubstring("invalid UAA URL")))
 
@@ -103,7 +104,7 @@ var _ = Describe("BuildClient", func() {
 		caCertPath := "-----BEGIN"
 		basicAuthDirectorURL := director.URL
 
-		_, err := BuildClient(basicAuthDirectorURL, username, password, caCertPath, bbrVersion, logger)
+		_, err := BuildClient(basicAuthDirectorURL, username, password, caCertPath, bbrVersion, ratelimiter.NoOpRateLimiter{}, logger)
 		Expect(err).To(MatchError(ContainSubstring("Missing PEM block")))
 	})
 
@@ -113,7 +114,7 @@ var _ = Describe("BuildClient", func() {
 		caCertPath := ""
 		basicAuthDirectorURL := ""
 
-		_, err := BuildClient(basicAuthDirectorURL, username, password, caCertPath, bbrVersion, logger)
+		_, err := BuildClient(basicAuthDirectorURL, username, password, caCertPath, bbrVersion, ratelimiter.NoOpRateLimiter{}, logger)
 		Expect(err).To(MatchError(ContainSubstring("invalid bosh URL")))
 	})
 
@@ -125,7 +126,7 @@ var _ = Describe("BuildClient", func() {
 			mockbosh.Info().Fails("fooo!"),
 		)
 
-		_, err := BuildClient(director.URL, username, password, caCert, bbrVersion, logger)
+		_, err := BuildClient(director.URL, username, password, caCert, bbrVersion, ratelimiter.NoOpRateLimiter{}, logger)
 		Expect(err).To(MatchError(ContainSubstring("bosh director unreachable or unhealthy")))
 	})
 })

--- a/cli/command/all_deployments.go
+++ b/cli/command/all_deployments.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/executor/deployment"
 	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/factory"
 	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/orchestrator"
+	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/ratelimiter"
 	"github.com/urfave/cli"
 )
 
@@ -126,6 +127,18 @@ func getDeploymentParams(c *cli.Context) (string, string, string, string, string
 	allDeployments := c.Parent().Bool("all-deployments")
 
 	return username, password, target, caCert, bbrVersion, debug, deployment, allDeployments
+}
+
+func getConnectionRateLimiter(c *cli.Context) (ratelimiter.RateLimiter, error) {
+	enabled := c.Parent().Bool("rate-limiting")
+	maxConnections := c.Parent().Int("rate-limiting-max-connections")
+	duration := c.Parent().String("rate-limiting-duration")
+
+	if enabled {
+		return ratelimiter.NewConnectionRateLimiter(maxConnections, duration)
+	}
+	return ratelimiter.NewNoOpRateLimiter(), nil
+
 }
 
 type DeploymentExecutable struct {

--- a/cli/command/deployment_pre_backup_check.go
+++ b/cli/command/deployment_pre_backup_check.go
@@ -30,13 +30,20 @@ func (d DeploymentPreBackupCheck) Cli() cli.Command {
 
 func (d DeploymentPreBackupCheck) Action(c *cli.Context) error {
 	username, password, target, caCert, bbrVersion, debug, deployment, allDeployments := getDeploymentParams(c)
+
+	rateLimiter, err := getConnectionRateLimiter(c)
+
+	if err != nil {
+		return err
+	}
+
 	var logger logger.Logger
 	if allDeployments {
 		logger, _ = factory.BuildBoshLoggerWithCustomBuffer(debug)
 	} else {
 		logger = factory.BuildBoshLogger(debug)
 	}
-	boshClient, err := factory.BuildBoshClient(target, username, password, caCert, bbrVersion, logger)
+	boshClient, err := factory.BuildBoshClient(target, username, password, caCert, bbrVersion, rateLimiter, logger)
 	if err != nil {
 		return processError(orchestrator.NewError(err))
 	}

--- a/cli/command/deployment_restore.go
+++ b/cli/command/deployment_restore.go
@@ -37,12 +37,19 @@ func (d DeploymentRestoreCommand) Action(c *cli.Context) error {
 	deployment := c.Parent().String("deployment")
 	artifactPath := c.String("artifact-path")
 
+	rateLimiter, err := getConnectionRateLimiter(c)
+
+	if err != nil {
+		return err
+	}
+
 	restorer, err := factory.BuildDeploymentRestorer(c.Parent().String("target"),
 		c.Parent().String("username"),
 		c.Parent().String("password"),
 		c.Parent().String("ca-cert"),
 		c.App.Version,
-		c.GlobalBool("debug"))
+		c.GlobalBool("debug"),
+		rateLimiter)
 
 	if err != nil {
 		return processError(orchestrator.NewError(err))

--- a/cli/command/deployment_restore_cleanup.go
+++ b/cli/command/deployment_restore_cleanup.go
@@ -24,13 +24,20 @@ func (d DeploymentRestoreCleanupCommand) Cli() cli.Command {
 func (d DeploymentRestoreCleanupCommand) Action(c *cli.Context) error {
 	trapSigint(true)
 
+	rateLimiter, err := getConnectionRateLimiter(c)
+
+	if err != nil {
+		return err
+	}
+
 	cleaner, err := factory.BuildDeploymentRestoreCleanuper(c.Parent().String("target"),
 		c.Parent().String("username"),
 		c.Parent().String("password"),
 		c.Parent().String("ca-cert"),
 		c.App.Version,
 		c.Bool("with-manifest"),
-		c.GlobalBool("debug"))
+		c.GlobalBool("debug"),
+		rateLimiter)
 
 	if err != nil {
 		return processError(orchestrator.NewError(err))

--- a/cli/command/director_backup.go
+++ b/cli/command/director_backup.go
@@ -36,12 +36,19 @@ func (checkCommand DirectorBackupCommand) Action(c *cli.Context) error {
 	directorName := extractNameFromAddress(c.Parent().String("host"))
 	timeStamp := time.Now().UTC().Format(artifactTimeStampFormat)
 
+	rateLimiter, err := getConnectionRateLimiter(c)
+
+	if err != nil {
+		return err
+	}
+
 	backuper := factory.BuildDirectorBackuper(
 		c.Parent().String("host"),
 		c.Parent().String("username"),
 		c.Parent().String("private-key-path"),
 		c.App.Version,
 		c.GlobalBool("debug"),
+		rateLimiter,
 		timeStamp)
 
 	backupErr := backuper.Backup(directorName, c.String("artifact-path"))

--- a/cli/command/director_backup_cleanup.go
+++ b/cli/command/director_backup_cleanup.go
@@ -24,11 +24,18 @@ func (d DirectorBackupCleanupCommand) Action(c *cli.Context) error {
 
 	directorName := extractNameFromAddress(c.Parent().String("host"))
 
+	rateLimiter, err := getConnectionRateLimiter(c)
+
+	if err != nil {
+		return err
+	}
+
 	cleaner := factory.BuildDirectorBackupCleaner(c.Parent().String("host"),
 		c.Parent().String("username"),
 		c.Parent().String("private-key-path"),
 		c.App.Version,
 		c.GlobalBool("debug"),
+		rateLimiter,
 	)
 
 	cleanupErr := cleaner.Cleanup(directorName)

--- a/cli/command/director_restore.go
+++ b/cli/command/director_restore.go
@@ -38,12 +38,19 @@ func (cmd DirectorRestoreCommand) Action(c *cli.Context) error {
 	directorName := extractNameFromAddress(c.Parent().String("host"))
 	artifactPath := c.String("artifact-path")
 
+	rateLimiter, err := getConnectionRateLimiter(c)
+
+	if err != nil {
+		return err
+	}
+
 	restorer := factory.BuildDirectorRestorer(
 		c.Parent().String("host"),
 		c.Parent().String("username"),
 		c.Parent().String("private-key-path"),
 		c.App.Version,
 		c.GlobalBool("debug"),
+		rateLimiter,
 	)
 
 	restoreErr := restorer.Restore(directorName, artifactPath)

--- a/cli/command/director_restore_cleanup.go
+++ b/cli/command/director_restore_cleanup.go
@@ -24,12 +24,19 @@ func (d DirectorRestoreCleanupCommand) Action(c *cli.Context) error {
 
 	directorName := extractNameFromAddress(c.Parent().String("host"))
 
+	rateLimiter, err := getConnectionRateLimiter(c)
+
+	if err != nil {
+		return err
+	}
+
 	cleaner := factory.BuildDirectorRestoreCleaner(
 		c.Parent().String("host"),
 		c.Parent().String("username"),
 		c.Parent().String("private-key-path"),
 		c.App.Version,
 		c.GlobalBool("debug"),
+		rateLimiter,
 	)
 
 	cleanupErr := cleaner.Cleanup(directorName)

--- a/cmd/bbr/main.go
+++ b/cmd/bbr/main.go
@@ -143,6 +143,20 @@ func availableDeploymentFlags() []cli.Flag {
 			Name:  "all-deployments",
 			Usage: "Run command for all deployments. Omit if '--deployment' is provided. Currently only supported for: pre-backup-check, backup and backup-cleanup",
 		},
+		cli.BoolFlag{
+			Name:  "rate-limiting",
+			Usage: "Enable ssh connection rate limiting",
+		},
+		cli.IntFlag{
+			Name:  "rate-limiting-max-connections",
+			Usage: "Set the maximum amount of ssh connections that can be opened in configurable duration window (used with --rate-limiting)",
+			Value: 20,
+		},
+		cli.StringFlag{
+			Name:  "rate-limiting-duration",
+			Usage: "Set the duration window (example: 20s or 1m) (used with --rate-limiting)",
+			Value: "60s",
+		},
 	}
 }
 
@@ -166,6 +180,20 @@ func availableDirectorFlags() []cli.Flag {
 		cli.BoolFlag{
 			Name:  "debug",
 			Usage: "Enable debug logs",
+		},
+		cli.BoolFlag{
+			Name:  "rate-limiting",
+			Usage: "Enable ssh connection rate limiting",
+		},
+		cli.IntFlag{
+			Name:  "rate-limiting-max-connections",
+			Usage: "Set the maximum amount of ssh connections that can be opened in configurable duration window (used with --rate-limiting)",
+			Value: 20,
+		},
+		cli.StringFlag{
+			Name:  "rate-limiting-duration",
+			Usage: "Set the duration window (example: 20s or 1m) (used with --rate-limiting)",
+			Value: "60s",
 		},
 	}
 }

--- a/factory/bosh_deployment_manager.go
+++ b/factory/bosh_deployment_manager.go
@@ -2,13 +2,14 @@ package factory
 
 import (
 	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/bosh"
+	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/ratelimiter"
 	boshlog "github.com/cloudfoundry/bosh-utils/logger"
 
 	boshcmd "github.com/cloudfoundry/bosh-cli/v7/cmd/opts"
 	boshsys "github.com/cloudfoundry/bosh-utils/system"
 )
 
-func BuildBoshClient(targetUrl, username, password, caCertPathOrValue, bbrVersion string, logger boshlog.Logger) (bosh.Client, error) {
+func BuildBoshClient(targetUrl, username, password, caCertPathOrValue, bbrVersion string, rateLimiter ratelimiter.RateLimiter, logger boshlog.Logger) (bosh.Client, error) {
 	var boshClient bosh.Client
 	var err error
 	fs := boshsys.NewOsFileSystem(logger)
@@ -20,7 +21,7 @@ func BuildBoshClient(targetUrl, username, password, caCertPathOrValue, bbrVersio
 		return boshClient, err
 	}
 
-	boshClient, err = bosh.BuildClient(targetUrl, username, password, caCertArg.Content, bbrVersion, logger)
+	boshClient, err = bosh.BuildClient(targetUrl, username, password, caCertArg.Content, bbrVersion, rateLimiter, logger)
 	if err != nil {
 		return boshClient, err
 	}

--- a/factory/deployment_backup_cleanuper.go
+++ b/factory/deployment_backup_cleanuper.go
@@ -5,6 +5,7 @@ import (
 	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/executor"
 	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/orchestrator"
 	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/orderer"
+	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/ratelimiter"
 	"github.com/cloudfoundry/bosh-utils/logger"
 )
 
@@ -14,10 +15,11 @@ func BuildDeploymentBackupCleanuper(
 	password,
 	caCert,
 	bbrVersion string,
+	rateLimiter ratelimiter.RateLimiter,
 	logger logger.Logger,
 ) (*orchestrator.BackupCleaner, error) {
 
-	boshClient, err := BuildBoshClient(target, username, password, caCert, bbrVersion, logger)
+	boshClient, err := BuildBoshClient(target, username, password, caCert, bbrVersion, rateLimiter, logger)
 
 	if err != nil {
 		return nil, err

--- a/factory/deployment_backuper.go
+++ b/factory/deployment_backuper.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/executor"
 	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/orchestrator"
 	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/orderer"
+	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/ratelimiter"
 	boshlog "github.com/cloudfoundry/bosh-utils/logger"
 )
 
@@ -19,10 +20,11 @@ func BuildDeploymentBackuper(
 	withManifest bool,
 	unsafeLockFree bool,
 	bbrVersion string,
+	rateLimiter ratelimiter.RateLimiter,
 	logger boshlog.Logger,
 	timestamp string,
 ) (*orchestrator.Backuper, error) {
-	boshClient, err := BuildBoshClient(target, username, password, caCert, bbrVersion, logger)
+	boshClient, err := BuildBoshClient(target, username, password, caCert, bbrVersion, rateLimiter, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/factory/deployment_restore_cleanuper.go
+++ b/factory/deployment_restore_cleanuper.go
@@ -5,6 +5,7 @@ import (
 	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/executor"
 	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/orchestrator"
 	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/orderer"
+	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/ratelimiter"
 )
 
 func BuildDeploymentRestoreCleanuper(target,
@@ -13,7 +14,8 @@ func BuildDeploymentRestoreCleanuper(target,
 	caCert,
 	bbrVersion string,
 	withManifest,
-	isDebug bool) (*orchestrator.RestoreCleaner, error) {
+	isDebug bool,
+	rateLimiter ratelimiter.RateLimiter) (*orchestrator.RestoreCleaner, error) {
 
 	logger := BuildLogger(isDebug)
 
@@ -23,6 +25,7 @@ func BuildDeploymentRestoreCleanuper(target,
 		password,
 		caCert,
 		bbrVersion,
+		rateLimiter,
 		logger,
 	)
 

--- a/factory/deployment_restorer.go
+++ b/factory/deployment_restorer.go
@@ -6,9 +6,10 @@ import (
 	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/executor"
 	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/orchestrator"
 	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/orderer"
+	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/ratelimiter"
 )
 
-func BuildDeploymentRestorer(target, username, password, caCert, bbrVersion string, debug bool) (*orchestrator.Restorer, error) {
+func BuildDeploymentRestorer(target, username, password, caCert, bbrVersion string, debug bool, rateLimiter ratelimiter.RateLimiter) (*orchestrator.Restorer, error) {
 	logger := BuildLogger(debug)
 	boshClient, err := BuildBoshClient(
 		target,
@@ -16,6 +17,7 @@ func BuildDeploymentRestorer(target, username, password, caCert, bbrVersion stri
 		password,
 		caCert,
 		bbrVersion,
+		rateLimiter,
 		logger,
 	)
 	if err != nil {

--- a/factory/director_backup_checker.go
+++ b/factory/director_backup_checker.go
@@ -4,11 +4,12 @@ import (
 	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/instance"
 	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/orchestrator"
 	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/orderer"
+	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/ratelimiter"
 	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/ssh"
 	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/standalone"
 )
 
-func BuildDirectorBackupChecker(host, username, privateKeyPath, bbrVersion string, hasDebug bool) *orchestrator.BackupChecker {
+func BuildDirectorBackupChecker(host, username, privateKeyPath, bbrVersion string, hasDebug bool, rateLimiter ratelimiter.RateLimiter) *orchestrator.BackupChecker {
 	logger := BuildLogger(hasDebug)
 	deploymentManager := standalone.NewDeploymentManager(logger,
 		host,
@@ -16,6 +17,7 @@ func BuildDirectorBackupChecker(host, username, privateKeyPath, bbrVersion strin
 		privateKeyPath,
 		instance.NewJobFinderOmitMetadataReleases(bbrVersion, logger),
 		ssh.NewSshRemoteRunner,
+		rateLimiter,
 	)
 
 	return orchestrator.NewBackupChecker(logger, deploymentManager, orderer.NewKahnBackupLockOrderer())

--- a/factory/director_backup_cleaner.go
+++ b/factory/director_backup_cleaner.go
@@ -5,6 +5,7 @@ import (
 	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/instance"
 	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/orchestrator"
 	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/orderer"
+	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/ratelimiter"
 	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/ssh"
 	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/standalone"
 )
@@ -13,7 +14,8 @@ func BuildDirectorBackupCleaner(host,
 	username,
 	privateKeyPath,
 	bbrVersion string,
-	hasDebug bool) *orchestrator.BackupCleaner {
+	hasDebug bool,
+	rateLimiter ratelimiter.RateLimiter) *orchestrator.BackupCleaner {
 
 	logger := BuildLogger(hasDebug)
 	deploymentManager := standalone.NewDeploymentManager(logger,
@@ -22,6 +24,7 @@ func BuildDirectorBackupCleaner(host,
 		privateKeyPath,
 		instance.NewJobFinderOmitMetadataReleases(bbrVersion, logger),
 		ssh.NewSshRemoteRunner,
+		rateLimiter,
 	)
 
 	return orchestrator.NewBackupCleaner(logger, deploymentManager, orderer.NewKahnBackupLockOrderer(), executor.NewParallelExecutor())

--- a/factory/director_backuper.go
+++ b/factory/director_backuper.go
@@ -8,11 +8,12 @@ import (
 	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/instance"
 	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/orchestrator"
 	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/orderer"
+	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/ratelimiter"
 	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/ssh"
 	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/standalone"
 )
 
-func BuildDirectorBackuper(host, username, privateKeyPath, bbrVersion string, hasDebug bool, timeStamp string) *orchestrator.Backuper {
+func BuildDirectorBackuper(host, username, privateKeyPath, bbrVersion string, hasDebug bool, rateLimiter ratelimiter.RateLimiter, timeStamp string) *orchestrator.Backuper {
 	logger := BuildLogger(hasDebug)
 	deploymentManager := standalone.NewDeploymentManager(logger,
 		host,
@@ -20,6 +21,7 @@ func BuildDirectorBackuper(host, username, privateKeyPath, bbrVersion string, ha
 		privateKeyPath,
 		instance.NewJobFinderOmitMetadataReleases(bbrVersion, logger),
 		ssh.NewSshRemoteRunner,
+		rateLimiter,
 	)
 	execr := executor.NewParallelExecutor()
 

--- a/factory/director_restore_cleaner.go
+++ b/factory/director_restore_cleaner.go
@@ -5,6 +5,7 @@ import (
 	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/instance"
 	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/orchestrator"
 	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/orderer"
+	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/ratelimiter"
 	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/ssh"
 	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/standalone"
 )
@@ -13,7 +14,8 @@ func BuildDirectorRestoreCleaner(host,
 	username,
 	privateKeyPath,
 	bbrVersion string,
-	hasDebug bool) *orchestrator.RestoreCleaner {
+	hasDebug bool,
+	rateLimiter ratelimiter.RateLimiter) *orchestrator.RestoreCleaner {
 
 	logger := BuildLogger(hasDebug)
 
@@ -23,6 +25,7 @@ func BuildDirectorRestoreCleaner(host,
 		privateKeyPath,
 		instance.NewJobFinderOmitMetadataReleases(bbrVersion, logger),
 		ssh.NewSshRemoteRunner,
+		rateLimiter,
 	)
 
 	return orchestrator.NewRestoreCleaner(logger, deploymentManager, orderer.NewKahnRestoreLockOrderer(), executor.NewSerialExecutor())

--- a/factory/director_restorer.go
+++ b/factory/director_restorer.go
@@ -6,11 +6,12 @@ import (
 	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/instance"
 	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/orchestrator"
 	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/orderer"
+	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/ratelimiter"
 	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/ssh"
 	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/standalone"
 )
 
-func BuildDirectorRestorer(host, username, privateKeyPath, bbrVersion string, hasDebug bool) *orchestrator.Restorer {
+func BuildDirectorRestorer(host, username, privateKeyPath, bbrVersion string, hasDebug bool, rateLimiter ratelimiter.RateLimiter) *orchestrator.Restorer {
 	logger := BuildLogger(hasDebug)
 	deploymentManager := standalone.NewDeploymentManager(logger,
 		host,
@@ -18,6 +19,7 @@ func BuildDirectorRestorer(host, username, privateKeyPath, bbrVersion string, ha
 		privateKeyPath,
 		instance.NewJobFinderOmitMetadataReleases(bbrVersion, logger),
 		ssh.NewSshRemoteRunner,
+		rateLimiter,
 	)
 
 	return orchestrator.NewRestorer(

--- a/ratelimiter/connection_rate_limiter.go
+++ b/ratelimiter/connection_rate_limiter.go
@@ -1,0 +1,53 @@
+package ratelimiter
+
+import (
+	"errors"
+	"fmt"
+	"time"
+)
+
+type RateLimiter interface {
+	RateLimit()
+}
+
+type ConnectionRateLimiter struct {
+	guard    chan bool
+	duration time.Duration
+}
+
+func NewConnectionRateLimiter(maxConnections int, durationString string) (RateLimiter, error) {
+
+	if maxConnections < 1 || maxConnections > 100 {
+		errorMessage := "max connections cannot be less than 1 or greater than 100"
+		fmt.Println(errorMessage)
+		return nil, errors.New(errorMessage)
+	}
+
+	duration, err := time.ParseDuration(durationString)
+
+	if err != nil {
+		fmt.Printf("unable to parse rating limit duration: %s\n", err.Error())
+		return nil, err
+	}
+
+	if duration <= 0 || duration > (3600*time.Second) {
+		errorMessage := "duration cannot be 0 or greater than 3600 seconds"
+		fmt.Println(errorMessage)
+		return nil, errors.New(errorMessage)
+	}
+
+	return &ConnectionRateLimiter{
+		guard:    make(chan bool, maxConnections),
+		duration: duration,
+	}, nil
+}
+
+func (t *ConnectionRateLimiter) RateLimit() {
+
+	t.guard <- true
+
+	go func() {
+		time.Sleep(t.duration)
+		<-t.guard
+	}()
+}

--- a/ratelimiter/connection_rate_limiter_test.go
+++ b/ratelimiter/connection_rate_limiter_test.go
@@ -1,0 +1,76 @@
+package ratelimiter_test
+
+import (
+	"context"
+	"time"
+
+	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/ratelimiter"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ConnectionRateLimiter", func() {
+
+	Describe("RateLimit", func() {
+		Context("success", func() {
+			It("rate limits", func(ctx context.Context) {
+				rateLimiter, err := ratelimiter.NewConnectionRateLimiter(5, "1s")
+
+				Expect(err).To(BeNil())
+
+				completion := make(chan struct{}, 10)
+
+				for i := 0; i < 10; i++ {
+					go func() {
+						rateLimiter.RateLimit()
+						completion <- struct{}{}
+					}()
+				}
+
+				time.Sleep(10 * time.Millisecond)
+				Expect(completion).To(HaveLen(5))
+
+				time.Sleep(1 * time.Second)
+				Expect(completion).To(HaveLen(10))
+
+			}, SpecTimeout(2*time.Second))
+		})
+
+		Context("failure", func() {
+			It("throws and error if rate limit is less than 1", func() {
+				_, err := ratelimiter.NewConnectionRateLimiter(0, "1s")
+
+				Expect(err).NotTo(BeNil())
+				Expect(err.Error()).To(ContainSubstring("less than 1"))
+			})
+
+			It("throws and error if rate limit is greater than 100", func() {
+				_, err := ratelimiter.NewConnectionRateLimiter(101, "1s")
+
+				Expect(err).NotTo(BeNil())
+				Expect(err.Error()).To(ContainSubstring("greater than 100"))
+			})
+
+			It("throws and error if duration is less than 1", func() {
+				_, err := ratelimiter.NewConnectionRateLimiter(5, "0s")
+
+				Expect(err).NotTo(BeNil())
+				Expect(err.Error()).To(ContainSubstring("cannot be 0"))
+			})
+
+			It("throws and error if duration is greater than 3600", func() {
+				_, err := ratelimiter.NewConnectionRateLimiter(5, "3601s")
+
+				Expect(err).NotTo(BeNil())
+				Expect(err.Error()).To(ContainSubstring("greater than 3600"))
+			})
+
+			It("throws and error if duration is invalid", func() {
+				_, err := ratelimiter.NewConnectionRateLimiter(5, "1yxz")
+
+				Expect(err).NotTo(BeNil())
+				Expect(err.Error()).To(ContainSubstring("duration \"1yxz\""))
+			})
+		})
+	})
+})

--- a/ratelimiter/noop_rate_limiter.go
+++ b/ratelimiter/noop_rate_limiter.go
@@ -1,0 +1,12 @@
+package ratelimiter
+
+type NoOpRateLimiter struct {
+}
+
+func NewNoOpRateLimiter() RateLimiter {
+	return NoOpRateLimiter{}
+}
+
+func (n NoOpRateLimiter) RateLimit() {
+
+}

--- a/ratelimiter/ratelimiter_suite_test.go
+++ b/ratelimiter/ratelimiter_suite_test.go
@@ -1,0 +1,13 @@
+package ratelimiter_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestRatelimiter(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Ratelimiter Suite")
+}

--- a/ssh/connection_test.go
+++ b/ssh/connection_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log"
 
+	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/ratelimiter"
 	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/ssh"
 	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/ssh/fakes"
 	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/testcluster"
@@ -52,7 +53,7 @@ var _ = Describe("Connection", func() {
 
 	JustBeforeEach(func() {
 
-		conn, connErr = ssh.NewConnection(hostname, user, privateKey, gossh.FixedHostKey(hostPublicKey), []string{"rsa-sha2-256"}, logger)
+		conn, connErr = ssh.NewConnection(hostname, user, privateKey, gossh.FixedHostKey(hostPublicKey), []string{"rsa-sha2-256"}, ratelimiter.NoOpRateLimiter{}, logger)
 	})
 
 	Describe("Connection Creation", func() {
@@ -329,7 +330,7 @@ var _ = Describe("Connection", func() {
 				echo "start"
 				sleep 4
 				echo "end"`)
-			conn, connErr = ssh.NewConnectionWithServerAliveInterval(hostname, user, privateKey, gossh.FixedHostKey(hostPublicKey), []string{"rsa-sha2-256"}, 1, logger)
+			conn, connErr = ssh.NewConnectionWithServerAliveInterval(hostname, user, privateKey, gossh.FixedHostKey(hostPublicKey), []string{"rsa-sha2-256"}, 1, ratelimiter.NoOpRateLimiter{}, logger)
 			Expect(connErr).NotTo(HaveOccurred())
 
 			stdOut, _, _, _ = conn.Run("/tmp/produce")
@@ -360,6 +361,7 @@ var _ = Describe("Connection", func() {
 				gossh.FixedHostKey(hostPublicKey),
 				[]string{"rsa-sha2-256"},
 				rapidKeepAliveSignalInterval,
+				ratelimiter.NoOpRateLimiter{},
 				logger)
 			Expect(connErr).NotTo(HaveOccurred())
 			stdErr, _, runError = conn.Stream(command, stdout)

--- a/ssh/fakes/fake_remote_runner_factory.go
+++ b/ssh/fakes/fake_remote_runner_factory.go
@@ -4,12 +4,13 @@ package fakes
 import (
 	"sync"
 
+	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/ratelimiter"
 	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/ssh"
 	ssha "golang.org/x/crypto/ssh"
 )
 
 type FakeRemoteRunnerFactory struct {
-	Stub        func(string, string, string, ssha.HostKeyCallback, []string, ssh.Logger) (ssh.RemoteRunner, error)
+	Stub        func(string, string, string, ssha.HostKeyCallback, []string, ratelimiter.RateLimiter, ssh.Logger) (ssh.RemoteRunner, error)
 	mutex       sync.RWMutex
 	argsForCall []struct {
 		arg1 string
@@ -17,7 +18,8 @@ type FakeRemoteRunnerFactory struct {
 		arg3 string
 		arg4 ssha.HostKeyCallback
 		arg5 []string
-		arg6 ssh.Logger
+		arg6 ratelimiter.RateLimiter
+		arg7 ssh.Logger
 	}
 	returns struct {
 		result1 ssh.RemoteRunner
@@ -31,7 +33,7 @@ type FakeRemoteRunnerFactory struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeRemoteRunnerFactory) Spy(arg1 string, arg2 string, arg3 string, arg4 ssha.HostKeyCallback, arg5 []string, arg6 ssh.Logger) (ssh.RemoteRunner, error) {
+func (fake *FakeRemoteRunnerFactory) Spy(arg1 string, arg2 string, arg3 string, arg4 ssha.HostKeyCallback, arg5 []string, arg6 ratelimiter.RateLimiter, arg7 ssh.Logger) (ssh.RemoteRunner, error) {
 	var arg5Copy []string
 	if arg5 != nil {
 		arg5Copy = make([]string, len(arg5))
@@ -45,14 +47,15 @@ func (fake *FakeRemoteRunnerFactory) Spy(arg1 string, arg2 string, arg3 string, 
 		arg3 string
 		arg4 ssha.HostKeyCallback
 		arg5 []string
-		arg6 ssh.Logger
-	}{arg1, arg2, arg3, arg4, arg5Copy, arg6})
+		arg6 ratelimiter.RateLimiter
+		arg7 ssh.Logger
+	}{arg1, arg2, arg3, arg4, arg5Copy, arg6, arg7})
 	stub := fake.Stub
 	returns := fake.returns
 	fake.recordInvocation("RemoteRunnerFactory", []interface{}{arg1, arg2, arg3, arg4, arg5Copy, arg6})
 	fake.mutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3, arg4, arg5, arg6)
+		return stub(arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -66,16 +69,16 @@ func (fake *FakeRemoteRunnerFactory) CallCount() int {
 	return len(fake.argsForCall)
 }
 
-func (fake *FakeRemoteRunnerFactory) Calls(stub func(string, string, string, ssha.HostKeyCallback, []string, ssh.Logger) (ssh.RemoteRunner, error)) {
+func (fake *FakeRemoteRunnerFactory) Calls(stub func(string, string, string, ssha.HostKeyCallback, []string, ratelimiter.RateLimiter, ssh.Logger) (ssh.RemoteRunner, error)) {
 	fake.mutex.Lock()
 	defer fake.mutex.Unlock()
 	fake.Stub = stub
 }
 
-func (fake *FakeRemoteRunnerFactory) ArgsForCall(i int) (string, string, string, ssha.HostKeyCallback, []string, ssh.Logger) {
+func (fake *FakeRemoteRunnerFactory) ArgsForCall(i int) (string, string, string, ssha.HostKeyCallback, []string, ratelimiter.RateLimiter, ssh.Logger) {
 	fake.mutex.RLock()
 	defer fake.mutex.RUnlock()
-	return fake.argsForCall[i].arg1, fake.argsForCall[i].arg2, fake.argsForCall[i].arg3, fake.argsForCall[i].arg4, fake.argsForCall[i].arg5, fake.argsForCall[i].arg6
+	return fake.argsForCall[i].arg1, fake.argsForCall[i].arg2, fake.argsForCall[i].arg3, fake.argsForCall[i].arg4, fake.argsForCall[i].arg5, fake.argsForCall[i].arg6, fake.argsForCall[i].arg7
 }
 
 func (fake *FakeRemoteRunnerFactory) Returns(result1 ssh.RemoteRunner, result2 error) {

--- a/ssh/remote_runner.go
+++ b/ssh/remote_runner.go
@@ -8,6 +8,7 @@ import (
 
 	"golang.org/x/crypto/ssh"
 
+	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/ratelimiter"
 	"github.com/pkg/errors"
 )
 
@@ -34,8 +35,8 @@ type SshRemoteRunner struct {
 	connection SSHConnection
 }
 
-func NewSshRemoteRunner(host, user, privateKey string, publicKeyCallback ssh.HostKeyCallback, publicKeyAlgorithm []string, logger Logger) (RemoteRunner, error) {
-	connection, err := NewConnection(host, user, privateKey, publicKeyCallback, publicKeyAlgorithm, logger)
+func NewSshRemoteRunner(host, user, privateKey string, publicKeyCallback ssh.HostKeyCallback, publicKeyAlgorithm []string, rateLimiter ratelimiter.RateLimiter, logger Logger) (RemoteRunner, error) {
+	connection, err := NewConnection(host, user, privateKey, publicKeyCallback, publicKeyAlgorithm, rateLimiter, logger)
 	if err != nil {
 		return SshRemoteRunner{}, err
 	}

--- a/ssh/remote_runner_factory.go
+++ b/ssh/remote_runner_factory.go
@@ -1,7 +1,10 @@
 package ssh
 
-import "golang.org/x/crypto/ssh"
+import (
+	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/ratelimiter"
+	"golang.org/x/crypto/ssh"
+)
 
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
 //counterfeiter:generate -o fakes/fake_remote_runner_factory.go . RemoteRunnerFactory
-type RemoteRunnerFactory func(host, user, privateKey string, publicKeyCallback ssh.HostKeyCallback, publicKeyAlgorithm []string, logger Logger) (RemoteRunner, error)
+type RemoteRunnerFactory func(host, user, privateKey string, publicKeyCallback ssh.HostKeyCallback, publicKeyAlgorithm []string, rateLimiter ratelimiter.RateLimiter, logger Logger) (RemoteRunner, error)

--- a/ssh/remote_runner_test.go
+++ b/ssh/remote_runner_test.go
@@ -7,6 +7,7 @@ import (
 
 	"os"
 
+	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/ratelimiter"
 	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/ssh"
 	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/testcluster"
 	boshlog "github.com/cloudfoundry/bosh-utils/logger"
@@ -37,11 +38,11 @@ var _ = Describe("SshRemoteRunner", func() {
 		logger := boshlog.New(boshlog.LevelDebug, combinedLog)
 
 		sshConnection, err = ssh.NewConnection(testInstance.Address(), user, userPrivateKey, gossh.FixedHostKey(hostPublicKey),
-			[]string{"rsa-sha2-256"}, logger)
+			[]string{"rsa-sha2-256"}, ratelimiter.NoOpRateLimiter{}, logger)
 		Expect(err).NotTo(HaveOccurred())
 
 		sshRemoteRunner, err = ssh.NewSshRemoteRunner(testInstance.Address(), user, userPrivateKey, gossh.FixedHostKey(hostPublicKey),
-			[]string{"rsa-sha2-256"}, logger)
+			[]string{"rsa-sha2-256"}, ratelimiter.NoOpRateLimiter{}, logger)
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/standalone/deployment_manager_test.go
+++ b/standalone/deployment_manager_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/instance"
+	"github.com/cloudfoundry-incubator/bosh-backup-and-restore/ratelimiter"
 	. "github.com/cloudfoundry-incubator/bosh-backup-and-restore/standalone"
 
 	instancefakes "github.com/cloudfoundry-incubator/bosh-backup-and-restore/instance/fakes"
@@ -35,7 +36,7 @@ var _ = Describe("DeploymentManager", func() {
 		fakeJobFinder = new(instancefakes.FakeJobFinder)
 		remoteRunner = new(sshfakes.FakeRemoteRunner)
 
-		deploymentManager = NewDeploymentManager(logger, hostName, username, privateKey, fakeJobFinder, remoteRunnerFactory.Spy)
+		deploymentManager = NewDeploymentManager(logger, hostName, username, privateKey, fakeJobFinder, remoteRunnerFactory.Spy, &ratelimiter.ConnectionRateLimiter{})
 	})
 
 	AfterEach(func() {


### PR DESCRIPTION
# Issue

* The BBR tool opens and closes multiple ssh connections during a single run
* Issues have been encountered with firewalls considering the multiple ssh connections as a brute force attack and kills the connections
* This particular firewall is configured to limit the amount of connections to a distinct host per a duration window (example: 20 connections per minute)

# Implementation
* Added a rate limiting feature that will throttle opening of new connections if too many have been opened within a given time frame
* The amount of connections and the duration window are both configurable, and the rate limiting feature itself can be toggled on

Example Usage:
```
bbr deployment \
--rate-limiting \
--rate-limiting-max-connections 10 \
--rate-limiting-duration 60s \
--deployment <deployment> backup
```

# Impact
* Without this feature, backups cannot be completed with the given firewall configuration in place
