### PR TITLE
ignore only the `build` folder that is in the top level

### DIFF
--- a/s3-config-validator/.gitignore
+++ b/s3-config-validator/.gitignore
@@ -1,1 +1,1 @@
-build
+/build


### PR DESCRIPTION
the `build` folder of the ginkgo dependency was also being accidentally ignored