### PR TITLE
add a go mod tidy before go mod vendor

### DIFF
--- a/ci/tasks/bbr-s3-config-validator-unit-test/task.sh
+++ b/ci/tasks/bbr-s3-config-validator-unit-test/task.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 cd bosh-backup-and-restore/s3-config-validator/src
+go mod tidy
 go mod vendor
 go run github.com/onsi/ginkgo/v2/ginkgo \
   -r \
@@ -15,4 +16,3 @@ go run github.com/onsi/ginkgo/v2/ginkgo \
   --progress \
   --skip="unreadable file" \
   internal
-


### PR DESCRIPTION
It’s generally a good practice to add a call to go mod tidy before running go mod vendor. This ensures that your go.mod file is up-to-date and accurately reflects the dependencies before running the tests.
Not calling go mod tidy caused an issue in one of the dependencies updates because go version needed to be changed to 1.23 from 1.22