### PR TITLE
update the go version used by the github action

### DIFF
--- a/.github/workflows/run-test-pyramid.yml
+++ b/.github/workflows/run-test-pyramid.yml
@@ -15,5 +15,5 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v5
       with:
-        go-version-file: go.mod
+        go-version: '1.23'
     - run: make test


### PR DESCRIPTION
there are multiple go mod files in this porject and since one of them at least was updated to 1.23, the go action should run with 1.23