### PR TITLE
fix(backup): isolate GetArtifactSize test temp dirs from parallel workers

### DIFF
--- a/backup/backup_directory_test.go
+++ b/backup/backup_directory_test.go
@@ -990,7 +990,7 @@ backup_activity:
 		)
 
 		BeforeEach(func() {
-			backupDir := os.TempDir()
+			backupDir := GinkgoT().TempDir()
 			jobName = "my-artifact"
 			filename := jobName + "-" + "0" + "-" + jobName + ".tar"
 			err := os.WriteFile(filepath.Join(backupDir, filename), []byte("this-is-a-4k-file"), 0600)
@@ -1034,7 +1034,7 @@ backup_activity:
 		)
 
 		BeforeEach(func() {
-			backupDir := os.TempDir()
+			backupDir := GinkgoT().TempDir()
 			jobName = "my-artifact-bytes"
 			filename := jobName + "-" + "0" + "-" + jobName + ".tar"
 			err := os.WriteFile(filepath.Join(backupDir, filename), []byte("this-is-a-4k-file"), 0600)


### PR DESCRIPTION
## Summary

- `GetArtifactSize` and `GetArtifactByteSize` `BeforeEach` blocks used `os.TempDir()` (i.e. `/tmp`) as their working directory, which is shared across all 31 parallel Ginkgo worker processes.
- `os.WriteFile` opens files with `O_TRUNC` before writing content, creating a race window where a concurrent worker's `os.Stat` (or `du`) call observes 0 bytes on the same path — causing the intermittent CI failures seen in builds 209 and 210.
- Replace `os.TempDir()` with `GinkgoT().TempDir()`, which allocates a unique per-spec temporary directory that is automatically cleaned up when the spec ends, eliminating the sharing window entirely.

## Root cause

The race in build 210 (after the previous fix):
1. Worker A's `BeforeEach`: opens `/tmp/my-artifact-bytes-0-my-artifact-bytes.tar` with `O_TRUNC` → file is now 0 bytes
2. Worker B (running a *different* spec): calls `os.Stat` on the same path → sees 0 bytes
3. Worker A's `BeforeEach`: finishes writing 17 bytes → too late

`GinkgoT().TempDir()` gives each spec its own directory (e.g. `/tmp/TestXxx123/`), so no two workers ever touch the same file path.

## Follows on from

PR #1611 which replaced `du`-based block counting with `os.Stat().Size()` — a correct fix that was masked by this deeper isolation issue.

## Test plan

- [x] `go run github.com/onsi/ginkgo/v2/ginkgo -p -r backup/` — all 65 specs pass with parallelism enabled (same flags as CI)

Made with [Cursor](https://cursor.com)