### PR TITLE
fix(backup): harden GetArtifactByteSize error handling and overflow safety

### DIFF
--- a/backup/backup_directory.go
+++ b/backup/backup_directory.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"os/exec"
 	"path"
@@ -46,10 +47,15 @@ func (backupDirectory *BackupDirectory) GetArtifactByteSize(artifactIdentifier o
 
 	info, err := os.Stat(filename)
 	if err != nil {
-		return 0, fmt.Errorf("failed to determine file size for file %s", filename)
+		return 0, fmt.Errorf("failed to determine file size for file %s: %w", filename, err)
 	}
 
-	return int(info.Size()), nil
+	size := info.Size()
+	if size > math.MaxInt {
+		return 0, fmt.Errorf("file %s is too large (%d bytes) to fit in an int; cannot compute percentage", filename, size)
+	}
+
+	return int(size), nil
 }
 
 func (backupDirectory *BackupDirectory) logAndReturn(err error, message string, args ...interface{}) error {


### PR DESCRIPTION
## Summary

Two improvements to `GetArtifactByteSize` following code review of [#1611](https://github.com/cloudfoundry/bosh-backup-and-restore/pull/1611):

- **Wrap `os.Stat` error**: the original error was discarded, making it impossible to distinguish \"file not found\" from \"permission denied\". Uses `%w` so callers can use `errors.Is`/`errors.As` and logs show the root cause.
- **Bounds check before `int64 → int` conversion**: on 32-bit platforms `int` is only 32 bits (~2 GB); silently truncating a larger value would produce a negative/incorrect size, breaking percentage logging. Returns a clear error for files that exceed `math.MaxInt`.

## Changes

```go
// Before
info, err := os.Stat(filename)
if err != nil {
    return 0, fmt.Errorf("failed to determine file size for file %s", filename)  // err dropped
}
return int(info.Size()), nil  // silent overflow on 32-bit

// After
info, err := os.Stat(filename)
if err != nil {
    return 0, fmt.Errorf("failed to determine file size for file %s: %w", filename, err)
}
size := info.Size()
if size > math.MaxInt {
    return 0, fmt.Errorf("file %s is too large (%d bytes) to fit in an int; cannot compute percentage", filename, size)
}
return int(size), nil
```

## Test plan

- [x] `go run github.com/onsi/ginkgo/v2/ginkgo -p -r backup/` — all 65 specs pass

> Note: changing the return type to `int64` throughout the call chain (`LogPercentage.totalSize`, `bytesRead`, `bytesWritten`, the interface, and the counterfeiter fake) is a larger refactor left for a follow-up if desired.

Made with [Cursor](https://cursor.com)